### PR TITLE
Detect bad planet files, rework raw features chart

### DIFF
--- a/dashboard/chart.js
+++ b/dashboard/chart.js
@@ -86,7 +86,7 @@ const [headerRow, ...rowStrs] = data.split("\r\n").slice(0, -1);
 const header = headerRow.split(",");
 const rows = rowStrs.map((rs) => rs.split(","));
 
-function dataForSeries(...series) {
+function dataForSeries(series, opts) {
   const idxs = [];
   for (const s of series) {
     const idx = header.indexOf(s);
@@ -101,7 +101,9 @@ function dataForSeries(...series) {
       .slice(1)
       .map((v) => Number(v)),
   );
-  idxs.sort((a, b) => lastRow[b] - lastRow[a]);
+  if (!opts?.doNotSort) {
+    idxs.sort((a, b) => lastRow[b] - lastRow[a]);
+  }
   const allIdxs = [0].concat(idxs); // always include the date
 
   const sliceRows = [];
@@ -132,7 +134,8 @@ function formatExample(txt) {
 function makeChart(container, series, options) {
   const chartEl = container.querySelector(".chart");
   const labelsEl = container.querySelector(".chart-labels");
-  const g = new Dygraph(chartEl, dataForSeries(...series), {
+  const data = Array.isArray(series) ? dataForSeries(series) : series;
+  const g = new Dygraph(chartEl, data, {
     labelsDiv: labelsEl,
     labelsSeparateLines: true,
     legend: "always",
@@ -260,17 +263,19 @@ makeChart(
 );
 
 {
-  const rawCounts = dataForSeries('num-nodes', 'num-ways', 'num-relations');
-  const [headers, ...rows] = rawCounts.split('\n').map(row => row.split(','));
+  const rawCounts = dataForSeries(['num-relations', 'num-ways', 'num-nodes'], {doNotSort: true});
+  const [header, ...rows] = rawCounts.split('\n').map(row => row.split(','));
   const initVals = rows[0].map((v, i) => i > 0 ? Number(v) : 0);
-  const vals = rows.map(row => row.map((v, i) => i === 0 ? new Date(v.replaceAll('-', '/')) : Number(v) / initVals[i]));
-  console.log(vals);
+  const vals = rows.map(row => row.map((v, i) => i === 0 ? v : Number(v) / initVals[i]));
+  const text = [header, ...vals].map(row => row.map(String).join(',')).join('\n');
 
-  new Dygraph(
-    document.querySelector('#raw-features .chart'),
-    vals,
-    {
-      labels: headers
-    }
-  );
+  makeChart(document.getElementById('raw-features'), text, {
+    examples: false,
+    axes: { y: { valueFormatter: (scaled, _a, _b, _c, row, col) => {
+      const rawVal = Number(rows[row][col]);
+      const rawStr = rawVal.toLocaleString();
+      const scaleStr = scaled.toLocaleString({numeric: {maximumSignificantDigits: 2}});
+      return `${rawStr} (${scaleStr}x)`;
+    }}}
+  })
 }

--- a/dashboard/chart.js
+++ b/dashboard/chart.js
@@ -249,16 +249,21 @@ makeChart(
 );
 
 makeChart(
-  document.getElementById('raw-features'),
-  [
-    "num-nodes",
-    "num-ways",
-    "num-relations"
-  ],
-  {
-    logscale: true,
-    examples: false,
-  }
+  document.getElementById('num-nodes'),
+  [ "num-nodes" ],
+  { examples: false, valueRange: [0, null], colors: [PALETTE[0]] }
+);
+
+makeChart(
+  document.getElementById('num-ways'),
+  [ "num-ways" ],
+  { examples: false, valueRange: [0, null], colors: [PALETTE[1]] }
+);
+
+makeChart(
+  document.getElementById('num-relations'),
+  [ "num-relations" ],
+  { examples: false, valueRange: [0, null], colors: [PALETTE[2]] }
 );
 
 makeChart(

--- a/dashboard/chart.js
+++ b/dashboard/chart.js
@@ -249,24 +249,6 @@ makeChart(
 );
 
 makeChart(
-  document.getElementById('num-nodes'),
-  [ "num-nodes" ],
-  { examples: false, valueRange: [0, null], colors: [PALETTE[0]] }
-);
-
-makeChart(
-  document.getElementById('num-ways'),
-  [ "num-ways" ],
-  { examples: false, valueRange: [0, null], colors: [PALETTE[1]] }
-);
-
-makeChart(
-  document.getElementById('num-relations'),
-  [ "num-relations" ],
-  { examples: false, valueRange: [0, null], colors: [PALETTE[2]] }
-);
-
-makeChart(
   document.getElementById('dupes'),
   [
     'dupes'
@@ -276,3 +258,19 @@ makeChart(
     dateWindow: [Date.parse('2026-03-31'), Date.now()]
   }
 );
+
+{
+  const rawCounts = dataForSeries('num-nodes', 'num-ways', 'num-relations');
+  const [headers, ...rows] = rawCounts.split('\n').map(row => row.split(','));
+  const initVals = rows[0].map((v, i) => i > 0 ? Number(v) : 0);
+  const vals = rows.map(row => row.map((v, i) => i === 0 ? new Date(v.replaceAll('-', '/')) : Number(v) / initVals[i]));
+  console.log(vals);
+
+  new Dygraph(
+    document.querySelector('#raw-features .chart'),
+    vals,
+    {
+      labels: headers
+    }
+  );
+}

--- a/feature_stats.py
+++ b/feature_stats.py
@@ -1,8 +1,30 @@
 import argparse
 import json
 import subprocess
+import sys
+
+import osmium
+import osmium.filter
+import osmium.osm
 
 from stats import write_stats
+
+
+def count_empty_ways(osm_file: str) -> int:
+    fp = osmium.FileProcessor(osm_file, osmium.osm.WAY).with_filter(
+        osmium.filter.KeyFilter("name")
+    )
+    n_named_ways = 0
+    n_empty_ways = 0
+    for obj in fp:
+        if not isinstance(obj, osmium.osm.Way):
+            continue
+        n_named_ways += 1
+        if len(obj.nodes) == 0:
+            n_empty_ways += 1
+
+    sys.stderr.write(f"{osm_file}: {n_named_ways=} {n_empty_ways=}\n")
+    return n_empty_ways
 
 
 def main() -> None:
@@ -12,6 +34,12 @@ def main() -> None:
     parser.add_argument("osm_file", help="Path to the .osm.pbf file")
     parser.add_argument("--output_dir", default=".")
     args = parser.parse_args()
+
+    n_empty_ways = count_empty_ways(args.osm_file)
+    if n_empty_ways > 0:
+        sys.stderr.write(f"{args.osm_file} has empty ways and is likely corrupt.\n")
+        sys.stderr.write("No data will be written.\n")
+        sys.exit(1)
 
     out = subprocess.check_output(
         [

--- a/feature_stats.py
+++ b/feature_stats.py
@@ -4,26 +4,23 @@ import subprocess
 import sys
 
 import osmium
-import osmium.filter
 import osmium.osm
 
 from stats import write_stats
 
 
 def count_empty_ways(osm_file: str) -> int:
-    fp = osmium.FileProcessor(osm_file, osmium.osm.WAY).with_filter(
-        osmium.filter.KeyFilter("name")
-    )
-    n_named_ways = 0
+    fp = osmium.FileProcessor(osm_file, osmium.osm.WAY)
+    n_ways = 0
     n_empty_ways = 0
     for obj in fp:
         if not isinstance(obj, osmium.osm.Way):
             continue
-        n_named_ways += 1
+        n_ways += 1
         if len(obj.nodes) == 0:
             n_empty_ways += 1
 
-    sys.stderr.write(f"{osm_file}: {n_named_ways=} {n_empty_ways=}\n")
+    sys.stderr.write(f"{osm_file}: {n_ways=} {n_empty_ways=}\n")
     return n_empty_ways
 
 

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
 
     <h3>Raw features</h3>
 
-    <p>Total nodes, ways and relations in OHM.</p>
+    <p>Total nodes, ways and relations in OHM, scaled to counts at the start of 2024.</p>
     <div id="raw-features">
         <div class="chart-container">
             <div class="chart"></div>

--- a/index.html
+++ b/index.html
@@ -40,15 +40,6 @@
         </div>
     </div>
 
-    <h3>Raw features</h3>
-    <p>Total nodes, ways and relations in OHM. Note the log scale.</p>
-    <div id="raw-features">
-        <div class="chart-container">
-            <div class="chart"></div>
-            <div class="chart-labels"></div>
-        </div>
-    </div>
-
     <h2>Data Quality / Correctness</h2>
 
     <h3>Geometry Errors</h3>
@@ -115,6 +106,31 @@
         </div>
         <div class="examples"></div>
     </div>
+
+    <h2>Other Metrics</h2>
+
+    <h3>Raw features</h3>
+
+    <p>Total nodes, ways and relations in OHM.</p>
+    <div id="num-relations">
+        <div class="chart-container">
+            <div class="chart"></div>
+            <div class="chart-labels"></div>
+        </div>
+    </div>
+    <div id="num-ways">
+        <div class="chart-container">
+            <div class="chart"></div>
+            <div class="chart-labels"></div>
+        </div>
+    </div>
+    <div id="num-nodes">
+        <div class="chart-container">
+            <div class="chart"></div>
+            <div class="chart-labels"></div>
+        </div>
+    </div>
+
 
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/dygraph/2.2.1/dygraph.min.js"></script>
     <script type="module" src="/dashboard/chart.js"></script>

--- a/index.html
+++ b/index.html
@@ -112,25 +112,12 @@
     <h3>Raw features</h3>
 
     <p>Total nodes, ways and relations in OHM.</p>
-    <div id="num-relations">
+    <div id="raw-features">
         <div class="chart-container">
             <div class="chart"></div>
             <div class="chart-labels"></div>
         </div>
     </div>
-    <div id="num-ways">
-        <div class="chart-container">
-            <div class="chart"></div>
-            <div class="chart-labels"></div>
-        </div>
-    </div>
-    <div id="num-nodes">
-        <div class="chart-container">
-            <div class="chart"></div>
-            <div class="chart-labels"></div>
-        </div>
-    </div>
-
 
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/dygraph/2.2.1/dygraph.min.js"></script>
     <script type="module" src="/dashboard/chart.js"></script>


### PR DESCRIPTION
Bad planet dumps (e.g. 2025-05-01, 2025-01-15, 2025-01-12) are often indicated by a large number of ways with zero nodes. This should never happen otherwise, so it's safe to bail out.

Also reworks the "raw features" chart to be more legible:

<img width="1042" height="385" alt="image" src="https://github.com/user-attachments/assets/6119a222-c6c3-45b4-aa80-f823d04b6360" />

It's still not that interesting, so I moved it to the bottom.