### PR TITLE
Validate EDTF dates

### DIFF
--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -8,10 +8,20 @@ import osmium
 import osmium.filter
 from osmium.osm import Node, OSMObject, Relation, Way
 
-from dates import DateTuple, Range, overlaps, parse_ohm_date, parse_ohm_range, start_of_date
+from dates import (
+    DateTuple,
+    Range,
+    overlaps,
+    parse_ohm_date,
+    parse_ohm_range,
+    start_of_date,
+)
 from stats import log_start, write_stats
 
 NAME_RANGE_PAT = r"\(-?\d{3,}--?\d{3,}\)"
+# Matches OHM-style ranges written with ".." instead of the EDTF separator "/":
+# "1970..1977", "..1970", "1970.."
+DOT_DOT_EDTF_PAT = re.compile(r"^(-?\d[\d-]*)?\.\.(-?\d[\d-]*)?$")
 
 
 def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
@@ -26,8 +36,16 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
         hi = parsed.upper_strict()  # type: ignore[attr-defined]
     except Exception:
         return None
-    lo_tup: DateTuple = (lo.tm_year, lo.tm_mon, lo.tm_mday) if isinstance(lo, time.struct_time) else (-(10**12), 1, 1)
-    hi_tup: DateTuple = (hi.tm_year, hi.tm_mon, hi.tm_mday) if isinstance(hi, time.struct_time) else (10**12, 1, 1)
+    lo_tup: DateTuple = (
+        (lo.tm_year, lo.tm_mon, lo.tm_mday)
+        if isinstance(lo, time.struct_time)
+        else (-(10**12), 1, 1)
+    )
+    hi_tup: DateTuple = (
+        (hi.tm_year, hi.tm_mon, hi.tm_mday)
+        if isinstance(hi, time.struct_time)
+        else (10**12, 1, 1)
+    )
     return lo_tup, hi_tup
 
 
@@ -73,7 +91,9 @@ class DateExtractor(osmium.SimpleHandler):
         self.end_no_start = list[OsmKey]()
         self.far_future = []
         self.n_timeless = 0
+        self.n_edtf = 0
         self.invalid_edtf = []
+        self.n_dot_dot_edtf = 0
         self.edtf_mismatch = []
 
     def handle_object(self, typ: str, f: OSMObject):
@@ -126,6 +146,7 @@ class DateExtractor(osmium.SimpleHandler):
         if end_date and range[1][0] > FAR_FUTURE:
             self.far_future.append((typ, f.id, f"{end_date} {name}"))
 
+        has_edtf = False
         for plain_tag, edtf_tag in (
             ("start_date", "start_date:edtf"),
             ("end_date", "end_date:edtf"),
@@ -134,11 +155,13 @@ class DateExtractor(osmium.SimpleHandler):
             edtf_str = f.tags.get(edtf_tag)
             if not edtf_str:
                 continue
+            has_edtf = True
             interval = edtf_interval(edtf_str)
             if interval is None:
-                self.invalid_edtf.append(
-                    (typ, f.id, f"{edtf_tag}={edtf_str} {name}")
-                )
+                self.invalid_edtf.append((typ, f.id, f"{edtf_tag}={edtf_str} {name}"))
+                m = DOT_DOT_EDTF_PAT.match(edtf_str)
+                if m and (m.group(1) or m.group(2)):
+                    self.n_dot_dot_edtf += 1
                 continue
             if plain:
                 plain_parsed = parse_ohm_date(plain)
@@ -153,6 +176,9 @@ class DateExtractor(osmium.SimpleHandler):
                                 f"{plain_tag}={plain} vs {edtf_tag}={edtf_str} {name}",
                             )
                         )
+
+        if has_edtf:
+            self.n_edtf += 1
 
         self.id_to_dates[key] = range
         self.id_to_raw_dates[key] = (start_date or "", end_date or "")
@@ -320,7 +346,12 @@ def main() -> None:
         args.output_dir,
         "chronology",
         by_type,
-        {"dated-relations": n_dated_rels, "dated-timeless": handler.n_timeless},
+        {
+            "dated-relations": n_dated_rels,
+            "dated-timeless": handler.n_timeless,
+            "edtf-features": handler.n_edtf,
+            "edtf-invalid-dot-dot": handler.n_dot_dot_edtf,
+        },
     )
 
 

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -6,9 +6,9 @@ import re
 import time
 
 import edtf as edtf_lib
-from edtf.parser.parser_classes import UnspecifiedIntervalSection
 import osmium
 import osmium.filter
+from edtf.parser.parser_classes import UnspecifiedIntervalSection
 from osmium.osm import Node, OSMObject, Relation, Way
 
 from dates import (
@@ -89,6 +89,7 @@ def _is_one_day_off(
     except (ValueError, OverflowError):
         return False
 
+
 type OsmKey = tuple[str, int]  # {"n", "w", "r"} + ID
 
 # https://github.com/OpenHistoricalMap/iD/blob/7177516c0356f12a35a3a01e8ef599bada802d7f/modules/osm/tags.js#L389-L392
@@ -128,6 +129,7 @@ class DateExtractor(osmium.SimpleHandler):
         self.start_after_end = []
         self.end_no_start = list[OsmKey]()
         self.far_future = []
+        self.n_dated = 0
         self.n_timeless = 0
         self.n_edtf = 0
         self.invalid_edtf = []
@@ -145,6 +147,9 @@ class DateExtractor(osmium.SimpleHandler):
         start_date = f.tags.get("start_date")
         end_date = f.tags.get("end_date")
         name = f.tags.get("name:en") or f.tags.get("name") or ""
+        if start_date or end_date:
+            self.n_dated += 1
+
         if start_date:
             start_tup = parse_ohm_date(start_date)
             if not start_tup:
@@ -390,6 +395,7 @@ def main() -> None:
         by_type,
         {
             "dated-relations": n_dated_rels,
+            "dated-features": handler.n_dated,
             "dated-timeless": handler.n_timeless,
             "edtf-features": handler.n_edtf,
             "edtf-invalid-dot-dot": handler.n_dot_dot_edtf,

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -397,9 +397,9 @@ def main() -> None:
             "dated-relations": n_dated_rels,
             "dated-features": handler.n_dated,
             "dated-timeless": handler.n_timeless,
-            "edtf-features": handler.n_edtf,
-            "edtf-invalid-dot-dot": handler.n_dot_dot_edtf,
-            "edtf-mismatch-off-by-one-day": handler.n_edtf_off_by_one,
+            "date-edtf-features": handler.n_edtf,
+            "date-edtf-invalid-dot-dot": handler.n_dot_dot_edtf,
+            "date-edtf-mismatch-off-by-one-day": handler.n_edtf_off_by_one,
         },
     )
 

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -1,4 +1,5 @@
 import argparse
+import functools
 import itertools
 import re
 import time
@@ -24,6 +25,7 @@ NAME_RANGE_PAT = r"\(-?\d{3,}--?\d{3,}\)"
 DOT_DOT_EDTF_PAT = re.compile(r"^(-?\d[\d-]*)?\.\.(-?\d[\d-]*)?$")
 
 
+@functools.lru_cache(maxsize=None)
 def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
     """Parse an EDTF string and return (lower, upper) as DateTuples, or None on failure.
 

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -14,6 +14,7 @@ from osmium.osm import Node, OSMObject, Relation, Way
 from dates import (
     DateTuple,
     Range,
+    end_of_date,
     overlaps,
     parse_ohm_date,
     parse_ohm_range,
@@ -72,14 +73,19 @@ FAR_FUTURE = 2050
 ONE_DAY = datetime.timedelta(days=1)
 
 
-def _is_one_day_off(plain_tup: DateTuple, lo: DateTuple, hi: DateTuple) -> bool:
-    """Return True if plain_tup is exactly one day before lo or one day after hi."""
+def _is_one_day_off(
+    plain_lo: DateTuple, plain_hi: DateTuple, lo: DateTuple, hi: DateTuple
+) -> bool:
+    """Return True if the plain date range misses the EDTF interval by exactly one day.
+
+    Covers two cases: the plain range ends one day before the EDTF interval
+    starts, or starts one day after the EDTF interval ends.
+    """
     try:
-        plain_date = datetime.date(*plain_tup)
-        if plain_tup < lo:
-            return datetime.date(*lo) - plain_date == ONE_DAY
+        if plain_hi < lo:
+            return datetime.date(*lo) - datetime.date(*plain_hi) == ONE_DAY
         else:
-            return plain_date - datetime.date(*hi) == ONE_DAY
+            return datetime.date(*plain_lo) - datetime.date(*hi) == ONE_DAY
     except (ValueError, OverflowError):
         return False
 
@@ -199,9 +205,10 @@ class DateExtractor(osmium.SimpleHandler):
             if plain:
                 plain_parsed = parse_ohm_date(plain)
                 if plain_parsed:
-                    plain_tup = start_of_date(plain_parsed)
+                    plain_lo = start_of_date(plain_parsed)
+                    plain_hi = end_of_date(plain_parsed)
                     lo, hi = interval
-                    if not (lo <= plain_tup <= hi):
+                    if not (plain_lo <= hi and lo <= plain_hi):
                         self.edtf_mismatch.append(
                             (
                                 typ,
@@ -209,7 +216,7 @@ class DateExtractor(osmium.SimpleHandler):
                                 f"{plain_tag}={plain} vs {edtf_tag}={edtf_str} {name}",
                             )
                         )
-                        if _is_one_day_off(plain_tup, lo, hi):
+                        if _is_one_day_off(plain_lo, plain_hi, lo, hi):
                             self.n_edtf_off_by_one += 1
 
         if has_edtf:

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -1,15 +1,36 @@
 import argparse
 import itertools
 import re
+import time
 
+import edtf as edtf_lib
 import osmium
 import osmium.filter
 from osmium.osm import Node, OSMObject, Relation, Way
 
-from dates import Range, overlaps, parse_ohm_date, parse_ohm_range
+from dates import DateTuple, Range, overlaps, parse_ohm_date, parse_ohm_range, start_of_date
 from stats import log_start, write_stats
 
 NAME_RANGE_PAT = r"\(-?\d{3,}--?\d{3,}\)"
+
+
+def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
+    """Parse an EDTF string and return (lower, upper) as DateTuples, or None on failure.
+
+    Returns None if the string is not valid EDTF, or if the library cannot compute
+    strict bounds (e.g. partially-unspecified dates like '1X00-1X-1X').
+    """
+    try:
+        parsed = edtf_lib.parse_edtf(edtf_str)  # type: ignore[attr-defined]
+        lo = parsed.lower_strict()  # type: ignore[attr-defined]
+        hi = parsed.upper_strict()  # type: ignore[attr-defined]
+    except Exception:
+        return None
+    lo_tup: DateTuple = (lo.tm_year, lo.tm_mon, lo.tm_mday) if isinstance(lo, time.struct_time) else (-(10**12), 1, 1)
+    hi_tup: DateTuple = (hi.tm_year, hi.tm_mon, hi.tm_mday) if isinstance(hi, time.struct_time) else (10**12, 1, 1)
+    return lo_tup, hi_tup
+
+
 FAR_FUTURE = 2050
 
 type OsmKey = tuple[str, int]  # {"n", "w", "r"} + ID
@@ -52,6 +73,8 @@ class DateExtractor(osmium.SimpleHandler):
         self.end_no_start = list[OsmKey]()
         self.far_future = []
         self.n_timeless = 0
+        self.invalid_edtf = []
+        self.edtf_mismatch = []
 
     def handle_object(self, typ: str, f: OSMObject):
         name = f.tags.get("name")
@@ -102,6 +125,34 @@ class DateExtractor(osmium.SimpleHandler):
             self.far_future.append((typ, f.id, f"{start_date} {name}"))
         if end_date and range[1][0] > FAR_FUTURE:
             self.far_future.append((typ, f.id, f"{end_date} {name}"))
+
+        for plain_tag, edtf_tag in (
+            ("start_date", "start_date:edtf"),
+            ("end_date", "end_date:edtf"),
+        ):
+            plain = f.tags.get(plain_tag)
+            edtf_str = f.tags.get(edtf_tag)
+            if not edtf_str:
+                continue
+            interval = edtf_interval(edtf_str)
+            if interval is None:
+                self.invalid_edtf.append(
+                    (typ, f.id, f"{edtf_tag}={edtf_str} {name}")
+                )
+                continue
+            if plain:
+                plain_parsed = parse_ohm_date(plain)
+                if plain_parsed:
+                    plain_tup = start_of_date(plain_parsed)
+                    lo, hi = interval
+                    if not (lo <= plain_tup <= hi):
+                        self.edtf_mismatch.append(
+                            (
+                                typ,
+                                f.id,
+                                f"{plain_tag}={plain} vs {edtf_tag}={edtf_str} {name}",
+                            )
+                        )
 
         self.id_to_dates[key] = range
         self.id_to_raw_dates[key] = (start_date or "", end_date or "")
@@ -234,7 +285,12 @@ def main() -> None:
 
     handler = DateExtractor()
     handler.apply_file(
-        args.osm_file, filters=[osmium.filter.KeyFilter("start_date", "end_date")]
+        args.osm_file,
+        filters=[
+            osmium.filter.KeyFilter(
+                "start_date", "end_date", "start_date:edtf", "end_date:edtf"
+            )
+        ],
     )
 
     n_dated_rels = len(handler.id_to_dates)
@@ -252,6 +308,8 @@ def main() -> None:
         "date-end-no-start": [(typ, id, "") for typ, id in handler.end_no_start],
         "date-start-after-end": handler.start_after_end,
         "date-far-future": handler.far_future,
+        "date-edtf-invalid": handler.invalid_edtf,
+        "date-edtf-mismatch": handler.edtf_mismatch,
         "chronology-anonymous": ch.anonymous_chronologies,
         "chronology-undated-member": ch.undated_members,
         "chronology-overlapping-members": ch.overlapping_members,

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -46,14 +46,14 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
     # instead of infinity.  Detect and override to the correct infinite bound.
     if (
         hasattr(parsed, "lower")
-        and isinstance(parsed.lower, UnspecifiedIntervalSection)
-        and str(parsed.lower) == ""
+        and isinstance(parsed.lower, UnspecifiedIntervalSection)  # type: ignore[attr-defined]
+        and str(parsed.lower) == ""  # type: ignore[attr-defined]
     ):
         lo = float("-inf")
     if (
         hasattr(parsed, "upper")
-        and isinstance(parsed.upper, UnspecifiedIntervalSection)
-        and str(parsed.upper) == ""
+        and isinstance(parsed.upper, UnspecifiedIntervalSection)  # type: ignore[attr-defined]
+        and str(parsed.upper) == ""  # type: ignore[attr-defined]
     ):
         hi = float("inf")
     lo_tup: DateTuple = (

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import functools
 import itertools
 import re
@@ -68,6 +69,19 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
 
 
 FAR_FUTURE = 2050
+ONE_DAY = datetime.timedelta(days=1)
+
+
+def _is_one_day_off(plain_tup: DateTuple, lo: DateTuple, hi: DateTuple) -> bool:
+    """Return True if plain_tup is exactly one day before lo or one day after hi."""
+    try:
+        plain_date = datetime.date(*plain_tup)
+        if plain_tup < lo:
+            return datetime.date(*lo) - plain_date == ONE_DAY
+        else:
+            return plain_date - datetime.date(*hi) == ONE_DAY
+    except (ValueError, OverflowError):
+        return False
 
 type OsmKey = tuple[str, int]  # {"n", "w", "r"} + ID
 
@@ -113,6 +127,7 @@ class DateExtractor(osmium.SimpleHandler):
         self.invalid_edtf = []
         self.n_dot_dot_edtf = 0
         self.edtf_mismatch = []
+        self.n_edtf_off_by_one = 0
 
     def handle_object(self, typ: str, f: OSMObject):
         name = f.tags.get("name")
@@ -194,6 +209,8 @@ class DateExtractor(osmium.SimpleHandler):
                                 f"{plain_tag}={plain} vs {edtf_tag}={edtf_str} {name}",
                             )
                         )
+                        if _is_one_day_off(plain_tup, lo, hi):
+                            self.n_edtf_off_by_one += 1
 
         if has_edtf:
             self.n_edtf += 1
@@ -369,6 +386,7 @@ def main() -> None:
             "dated-timeless": handler.n_timeless,
             "edtf-features": handler.n_edtf,
             "edtf-invalid-dot-dot": handler.n_dot_dot_edtf,
+            "edtf-mismatch-off-by-one-day": handler.n_edtf_off_by_one,
         },
     )
 

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -30,12 +30,12 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
     """Parse an EDTF string and return (lower, upper) as DateTuples, or None on failure.
 
     Returns None if the string is not valid EDTF, or if the library cannot compute
-    strict bounds (e.g. partially-unspecified dates like '1X00-1X-1X').
+    fuzzy bounds (e.g. partially-unspecified dates like '1X00-1X-1X').
     """
     try:
         parsed = edtf_lib.parse_edtf(edtf_str)  # type: ignore[attr-defined]
-        lo = parsed.lower_strict()  # type: ignore[attr-defined]
-        hi = parsed.upper_strict()  # type: ignore[attr-defined]
+        lo = parsed.lower_fuzzy()  # type: ignore[attr-defined]
+        hi = parsed.upper_fuzzy()  # type: ignore[attr-defined]
     except Exception:
         return None
     lo_tup: DateTuple = (

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -5,6 +5,7 @@ import re
 import time
 
 import edtf as edtf_lib
+from edtf.parser.parser_classes import UnspecifiedIntervalSection
 import osmium
 import osmium.filter
 from osmium.osm import Node, OSMObject, Relation, Way
@@ -38,6 +39,21 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
         hi = parsed.upper_fuzzy()  # type: ignore[attr-defined]
     except Exception:
         return None
+    # "1752/" and "/1818" use an empty UnspecifiedIntervalSection for the open
+    # end.  The library resolves this to a computed fuzzy date (~10 years out)
+    # instead of infinity.  Detect and override to the correct infinite bound.
+    if (
+        hasattr(parsed, "lower")
+        and isinstance(parsed.lower, UnspecifiedIntervalSection)
+        and str(parsed.lower) == ""
+    ):
+        lo = float("-inf")
+    if (
+        hasattr(parsed, "upper")
+        and isinstance(parsed.upper, UnspecifiedIntervalSection)
+        and str(parsed.upper) == ""
+    ):
+        hi = float("inf")
     lo_tup: DateTuple = (
         (lo.tm_year, lo.tm_mon, lo.tm_mday)
         if isinstance(lo, time.struct_time)

--- a/dates.py
+++ b/dates.py
@@ -1,3 +1,4 @@
+import calendar
 import re
 from typing import Optional, Tuple
 
@@ -52,6 +53,17 @@ def start_of_date(parsed: Tuple[int, Optional[int], Optional[int]]) -> DateTuple
         return (year, 1, 1)
     if day is None:
         return (year, month, 1)
+    return (year, month, day)
+
+
+def end_of_date(parsed: Tuple[int, Optional[int], Optional[int]]) -> DateTuple:
+    year, month, day = parsed
+
+    if month is None:
+        return (year, 12, 31)
+    if day is None:
+        last_day = calendar.monthrange(year, month)[1]
+        return (year, month, last_day)
     return (year, month, day)
 
 

--- a/dates_test.py
+++ b/dates_test.py
@@ -4,6 +4,7 @@ from chrono_stats import _is_one_day_off, edtf_interval
 from dates import (
     NEG_INF,
     POS_INF,
+    DateTuple,
     duration_years,
     end_of_date,
     overlaps,
@@ -11,6 +12,20 @@ from dates import (
     parse_ohm_range,
     start_of_date,
 )
+
+
+def safe_edtf_interval(s: str) -> tuple[DateTuple, DateTuple]:
+    """Unwrap edtf_interval(), asserting the result is not None."""
+    result = edtf_interval(s)
+    assert result is not None, f"ei({s!r}) returned None"
+    return result
+
+
+def safe_parse_ohm_date(s: str) -> tuple[int, int | None, int | None]:
+    """Unwrap parse_ohm_date(), asserting the result is not None."""
+    result = parse_ohm_date(s)
+    assert result is not None, f"parse_ohm_date({s!r}) returned None"
+    return result
 
 
 class TestParseOhmDate:
@@ -224,26 +239,26 @@ class TestOverlaps:
 
 class TestEdtfInterval:
     def test_exact_day(self):
-        assert edtf_interval("1948-05-08") == ((1948, 5, 8), (1948, 5, 8))
+        assert safe_edtf_interval("1948-05-08") == ((1948, 5, 8), (1948, 5, 8))
 
     def test_year_month(self):
-        assert edtf_interval("1948-05") == ((1948, 5, 1), (1948, 5, 31))
+        assert safe_edtf_interval("1948-05") == ((1948, 5, 1), (1948, 5, 31))
 
     def test_year_only(self):
-        assert edtf_interval("1948") == ((1948, 1, 1), (1948, 12, 31))
+        assert safe_edtf_interval("1948") == ((1948, 1, 1), (1948, 12, 31))
 
     def test_approximate_year(self):
         # 1948~ uses lower_fuzzy/upper_fuzzy, which extends ~1 year in each direction
-        lo, hi = edtf_interval("1948~")
+        lo, hi = safe_edtf_interval("1948~")
         assert lo == (1947, 1, 1)
         assert hi == (1949, 12, 31)
 
     def test_interval(self):
-        assert edtf_interval("1944/1950") == ((1944, 1, 1), (1950, 12, 31))
+        assert safe_edtf_interval("1944/1950") == ((1944, 1, 1), (1950, 12, 31))
 
     def test_open_ended_upper_dotdot(self):
         # "1948/.." — explicit open end with ".."
-        lo, hi = edtf_interval("1948/..")
+        lo, hi = safe_edtf_interval("1948/..")
         assert lo == (1948, 1, 1)
         assert hi == (10**12, 1, 1)
 
@@ -251,21 +266,21 @@ class TestEdtfInterval:
         # "1752/" — open end written without ".."; the library returns a
         # computed fuzzy date (~10 years out) rather than infinity, so we
         # must override it.  end_date=1799 should be compatible.
-        lo, hi = edtf_interval("1752/")
+        lo, hi = safe_edtf_interval("1752/")
         assert lo == (1752, 1, 1)
         assert hi == (10**12, 1, 1)
         assert lo <= (1799, 1, 1) <= hi
 
     def test_open_ended_lower_dotdot(self):
         # "../1818" — explicit open start with ".."
-        lo, hi = edtf_interval("../1818")
+        lo, hi = safe_edtf_interval("../1818")
         assert lo == (-(10**12), 1, 1)
         assert hi == (1818, 12, 31)
 
     def test_open_ended_lower_bare_slash(self):
         # "/1818" — open start written without ".."; same library quirk as
         # the upper case.  start_date=1500 should be compatible.
-        lo, hi = edtf_interval("/1818")
+        lo, hi = safe_edtf_interval("/1818")
         assert lo == (-(10**12), 1, 1)
         assert hi == (1818, 12, 31)
         assert lo <= (1500, 1, 1) <= hi
@@ -295,34 +310,33 @@ class TestEdtfInterval:
     def test_mismatch_day_off_by_one(self):
         """The motivating example from the issue: end_date=1948-05-08, end_date:edtf=1948-05-09."""
         plain = (1948, 5, 8)
-        lo, hi = edtf_interval("1948-05-09")
+        lo, hi = safe_edtf_interval("1948-05-09")
         assert not (lo <= plain <= hi)
 
     def test_match_day_within_month(self):
         """A day-level plain date is within a month-level EDTF interval."""
         plain = (1948, 5, 8)
-        lo, hi = edtf_interval("1948-05")
+        lo, hi = safe_edtf_interval("1948-05")
         assert lo <= plain <= hi
 
     def test_match_day_within_year(self):
         """A day-level plain date is within a year-level EDTF interval."""
         plain = (1948, 5, 8)
-        lo, hi = edtf_interval("1948")
+        lo, hi = safe_edtf_interval("1948")
         assert lo <= plain <= hi
 
     def test_mismatch_wrong_year(self):
         plain = (1949, 1, 1)
-        lo, hi = edtf_interval("1948")
+        lo, hi = safe_edtf_interval("1948")
         assert not (lo <= plain <= hi)
 
     def test_year_plain_overlaps_edtf_sub_interval(self):
         # start_date=1971 covers [1971-01-01, 1971-12-31].
         # start_date:edtf=1971-07-02/1972-03-31 covers [1971-07-02, 1972-03-31].
         # These overlap, so this should NOT be flagged as a mismatch.
-        plain_parsed = parse_ohm_date("1971")
-        plain_lo = start_of_date(plain_parsed)
-        plain_hi = end_of_date(plain_parsed)
-        lo, hi = edtf_interval("1971-07-02/1972-03-31")
+        plain_lo = start_of_date(safe_parse_ohm_date("1971"))
+        plain_hi = end_of_date(safe_parse_ohm_date("1971"))
+        lo, hi = safe_edtf_interval("1971-07-02/1972-03-31")
         assert plain_lo <= hi and lo <= plain_hi  # overlaps — no mismatch
 
 
@@ -339,72 +353,72 @@ class TestEdtfWikiExamples:
 
     def test_year_only(self):
         # "Year only" — start_date=1970, start_date:edtf=1970
-        lo, hi = edtf_interval("1970")
+        lo, hi = safe_edtf_interval("1970")
         assert lo == (1970, 1, 1) and hi == (1970, 12, 31)
-        assert lo <= start_of_date(parse_ohm_date("1970")) <= hi
+        assert lo <= start_of_date(safe_parse_ohm_date("1970")) <= hi
 
     def test_approximate_date(self):
         # "Approximate date" — start_date=1849, start_date:edtf=1849~
-        lo, hi = edtf_interval("1849~")
-        assert lo <= start_of_date(parse_ohm_date("1849")) <= hi
+        lo, hi = safe_edtf_interval("1849~")
+        assert lo <= start_of_date(safe_parse_ohm_date("1849")) <= hi
 
     def test_uncertain_date(self):
         # "Uncertain date" — start_date=1804, start_date:edtf=1804?
-        lo, hi = edtf_interval("1804?")
-        assert lo <= start_of_date(parse_ohm_date("1804")) <= hi
+        lo, hi = safe_edtf_interval("1804?")
+        assert lo <= start_of_date(safe_parse_ohm_date("1804")) <= hi
 
     def test_date_range_interval(self):
         # "Date range" — start_date=1908, start_date:edtf=1906/1908
-        lo, hi = edtf_interval("1906/1908")
-        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+        lo, hi = safe_edtf_interval("1906/1908")
+        assert lo <= start_of_date(safe_parse_ohm_date("1908")) <= hi
 
     def test_date_range_set(self):
         # "Date range" — start_date=1908, start_date:edtf=[1906..1908]
-        lo, hi = edtf_interval("[1906..1908]")
-        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+        lo, hi = safe_edtf_interval("[1906..1908]")
+        assert lo <= start_of_date(safe_parse_ohm_date("1908")) <= hi
 
     def test_century_midpoint_interval(self):
         # "Century midpoint" — start_date=1750, start_date:edtf=1730/1770
-        lo, hi = edtf_interval("1730/1770")
-        assert lo <= start_of_date(parse_ohm_date("1750")) <= hi
+        lo, hi = safe_edtf_interval("1730/1770")
+        assert lo <= start_of_date(safe_parse_ohm_date("1750")) <= hi
 
     def test_century_midpoint_set(self):
         # "Century midpoint" — start_date=1750, start_date:edtf=[1730..1770]
-        lo, hi = edtf_interval("[1730..1770]")
-        assert lo <= start_of_date(parse_ohm_date("1750")) <= hi
+        lo, hi = safe_edtf_interval("[1730..1770]")
+        assert lo <= start_of_date(safe_parse_ohm_date("1750")) <= hi
 
     def test_decade(self):
         # "Decade" — start_date=1895, start_date:edtf=189X
-        lo, hi = edtf_interval("189X")
-        assert lo <= start_of_date(parse_ohm_date("1895")) <= hi
+        lo, hi = safe_edtf_interval("189X")
+        assert lo <= start_of_date(safe_parse_ohm_date("1895")) <= hi
 
     def test_date_before_interval(self):
         # "Date before" — start_date=1800, start_date:edtf=/1800
-        lo, hi = edtf_interval("/1800")
-        assert lo <= start_of_date(parse_ohm_date("1800")) <= hi
+        lo, hi = safe_edtf_interval("/1800")
+        assert lo <= start_of_date(safe_parse_ohm_date("1800")) <= hi
 
     def test_date_before_set(self):
         # "Date before" — start_date=1800, start_date:edtf=[..1800]
-        lo, hi = edtf_interval("[..1800]")
-        assert lo <= start_of_date(parse_ohm_date("1800")) <= hi
+        lo, hi = safe_edtf_interval("[..1800]")
+        assert lo <= start_of_date(safe_parse_ohm_date("1800")) <= hi
 
     def test_early_month_range(self):
         # "Early April 1992" — start_date=1992-04, start_date:edtf=1992-04-01/1992-04-10
-        lo, hi = edtf_interval("1992-04-01/1992-04-10")
-        assert lo <= start_of_date(parse_ohm_date("1992-04")) <= hi
+        lo, hi = safe_edtf_interval("1992-04-01/1992-04-10")
+        assert lo <= start_of_date(safe_parse_ohm_date("1992-04")) <= hi
 
     def test_season_autumn(self):
         # "Season" — start_date=1814, start_date:edtf=1814-23 (EDTF season 23 = autumn)
         # Season codes resolve to a sub-year interval, so a year-level plain date
         # (which maps to Jan 1 via start_of_date) falls before the autumn window.
         # This is a known limitation of the compatibility check for season-coded EDTF.
-        lo, hi = edtf_interval("1814-23")
+        lo, hi = safe_edtf_interval("1814-23")
         assert lo == (1814, 9, 1) and hi == (1814, 11, 30)
 
     def test_late_season(self):
         # "Late season" — start_date=1887, start_date:edtf=1887-39 (late autumn/winter)
         # Same caveat as test_season_autumn: year-level plain date falls outside interval.
-        lo, hi = edtf_interval("1887-39")
+        lo, hi = safe_edtf_interval("1887-39")
         assert lo == (1887, 9, 1) and hi == (1887, 12, 31)
 
     def test_datetime_not_supported_start(self):
@@ -418,63 +432,63 @@ class TestEdtfWikiExamples:
 
     def test_year_only_end(self):
         # "Year only" — end_date=1272, end_date:edtf=1272
-        lo, hi = edtf_interval("1272")
-        assert lo <= start_of_date(parse_ohm_date("1272")) <= hi
+        lo, hi = safe_edtf_interval("1272")
+        assert lo <= start_of_date(safe_parse_ohm_date("1272")) <= hi
 
     def test_circa(self):
         # "circa 1871" — end_date=1871, end_date:edtf=1871~
-        lo, hi = edtf_interval("1871~")
-        assert lo <= start_of_date(parse_ohm_date("1871")) <= hi
+        lo, hi = safe_edtf_interval("1871~")
+        assert lo <= start_of_date(safe_parse_ohm_date("1871")) <= hi
 
     def test_mid_century(self):
         # "Mid sixteenth century" — end_date=1550, end_date:edtf=1550~
-        lo, hi = edtf_interval("1550~")
-        assert lo <= start_of_date(parse_ohm_date("1550")) <= hi
+        lo, hi = safe_edtf_interval("1550~")
+        assert lo <= start_of_date(safe_parse_ohm_date("1550")) <= hi
 
     def test_decade_unknown_year(self):
         # "1960s" — end_date=1960, end_date:edtf=196X
-        lo, hi = edtf_interval("196X")
-        assert lo <= start_of_date(parse_ohm_date("1960")) <= hi
+        lo, hi = safe_edtf_interval("196X")
+        assert lo <= start_of_date(safe_parse_ohm_date("1960")) <= hi
 
     def test_century_unknown_decade(self):
         # "15th century" — end_date=1450, end_date:edtf=14XX
-        lo, hi = edtf_interval("14XX")
-        assert lo <= start_of_date(parse_ohm_date("1450")) <= hi
+        lo, hi = safe_edtf_interval("14XX")
+        assert lo <= start_of_date(safe_parse_ohm_date("1450")) <= hi
 
     def test_between_dates_interval(self):
         # "Between 1908 and 1909" — end_date=1908, end_date:edtf=1908/1909
-        lo, hi = edtf_interval("1908/1909")
-        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+        lo, hi = safe_edtf_interval("1908/1909")
+        assert lo <= start_of_date(safe_parse_ohm_date("1908")) <= hi
 
     def test_between_dates_set(self):
         # "Between 1908 and 1909" — end_date=1908, end_date:edtf=[1908..1909]
-        lo, hi = edtf_interval("[1908..1909]")
-        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+        lo, hi = safe_edtf_interval("[1908..1909]")
+        assert lo <= start_of_date(safe_parse_ohm_date("1908")) <= hi
 
     def test_early_period(self):
         # "Early 1840s" — end_date=1840, end_date:edtf=1840/1845
-        lo, hi = edtf_interval("1840/1845")
-        assert lo <= start_of_date(parse_ohm_date("1840")) <= hi
+        lo, hi = safe_edtf_interval("1840/1845")
+        assert lo <= start_of_date(safe_parse_ohm_date("1840")) <= hi
 
     def test_indefinite_end_interval(self):
         # "On or before 2000" — end_date=2000, end_date:edtf=/2000
-        lo, hi = edtf_interval("/2000")
-        assert lo <= start_of_date(parse_ohm_date("2000")) <= hi
+        lo, hi = safe_edtf_interval("/2000")
+        assert lo <= start_of_date(safe_parse_ohm_date("2000")) <= hi
 
     def test_indefinite_end_set(self):
         # "On or before 2000" — end_date=2000, end_date:edtf=[..2000]
-        lo, hi = edtf_interval("[..2000]")
-        assert lo <= start_of_date(parse_ohm_date("2000")) <= hi
+        lo, hi = safe_edtf_interval("[..2000]")
+        assert lo <= start_of_date(safe_parse_ohm_date("2000")) <= hi
 
     def test_as_of(self):
         # "Building shown on 1935 map" — end_date=1935, end_date:edtf=/1935
-        lo, hi = edtf_interval("/1935")
-        assert lo <= start_of_date(parse_ohm_date("1935")) <= hi
+        lo, hi = safe_edtf_interval("/1935")
+        assert lo <= start_of_date(safe_parse_ohm_date("1935")) <= hi
 
     def test_season_winter(self):
         # "Winter of 1940" — end_date=1940, end_date:edtf=1940-24 (EDTF season 24 = winter)
         # Same caveat as test_season_autumn: year-level plain date falls outside interval.
-        lo, hi = edtf_interval("1940-24")
+        lo, hi = safe_edtf_interval("1940-24")
         assert lo == (1940, 12, 1) and hi == (1940, 12, 31)
 
     def test_datetime_not_supported_end(self):

--- a/dates_test.py
+++ b/dates_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from chrono_stats import edtf_interval
 from dates import (
     NEG_INF,
     POS_INF,
@@ -192,3 +193,73 @@ class TestOverlaps:
         B = parse_ohm_range("1925", "1975")
         assert overlaps(A, B)
         assert overlaps(B, A)
+
+
+class TestEdtfInterval:
+    def test_exact_day(self):
+        assert edtf_interval("1948-05-08") == ((1948, 5, 8), (1948, 5, 8))
+
+    def test_year_month(self):
+        assert edtf_interval("1948-05") == ((1948, 5, 1), (1948, 5, 31))
+
+    def test_year_only(self):
+        assert edtf_interval("1948") == ((1948, 1, 1), (1948, 12, 31))
+
+    def test_approximate_year(self):
+        # 1948~ is uncertain/approximate but still bounded to that year
+        lo, hi = edtf_interval("1948~")
+        assert lo == (1948, 1, 1)
+        assert hi == (1948, 12, 31)
+
+    def test_interval(self):
+        assert edtf_interval("1944/1950") == ((1944, 1, 1), (1950, 12, 31))
+
+    def test_open_ended_upper(self):
+        lo, hi = edtf_interval("1948/..")
+        assert lo == (1948, 1, 1)
+        assert hi == (10**12, 1, 1)
+
+    def test_invalid_returns_none(self):
+        # Strings that are not valid EDTF at all
+        assert edtf_interval("not a date") is None
+        assert edtf_interval("unknown") is None
+
+    def test_invalid_ohm_style_qualifiers(self):
+        # OHM plain-date qualifiers are not valid EDTF
+        assert edtf_interval("c. 1900") is None
+        assert edtf_interval("ca. 1900") is None
+        assert edtf_interval("1900 (est.)") is None
+        assert edtf_interval("600 BC") is None
+
+    def test_invalid_ohm_range_in_edtf_field(self):
+        # OHM date ranges written with a dash are not valid EDTF
+        assert edtf_interval("1900-1910") is None
+
+    def test_unspecified_month_day_digits(self):
+        # Partially-unspecified dates with X in month/day parse successfully
+        # but lower_strict()/upper_strict() raise ValueError inside the library.
+        # edtf_interval must catch this and return None.
+        assert edtf_interval("1X00-1X-1X") is None
+
+    def test_mismatch_day_off_by_one(self):
+        """The motivating example from the issue: end_date=1948-05-08, end_date:edtf=1948-05-09."""
+        plain = (1948, 5, 8)
+        lo, hi = edtf_interval("1948-05-09")
+        assert not (lo <= plain <= hi)
+
+    def test_match_day_within_month(self):
+        """A day-level plain date is within a month-level EDTF interval."""
+        plain = (1948, 5, 8)
+        lo, hi = edtf_interval("1948-05")
+        assert lo <= plain <= hi
+
+    def test_match_day_within_year(self):
+        """A day-level plain date is within a year-level EDTF interval."""
+        plain = (1948, 5, 8)
+        lo, hi = edtf_interval("1948")
+        assert lo <= plain <= hi
+
+    def test_mismatch_wrong_year(self):
+        plain = (1949, 1, 1)
+        lo, hi = edtf_interval("1948")
+        assert not (lo <= plain <= hi)

--- a/dates_test.py
+++ b/dates_test.py
@@ -5,6 +5,7 @@ from dates import (
     NEG_INF,
     POS_INF,
     duration_years,
+    end_of_date,
     overlaps,
     parse_ohm_date,
     parse_ohm_range,
@@ -63,6 +64,32 @@ class TestParseOhmDate:
         assert parse_ohm_date("600 BC") is None
         assert parse_ohm_date("1975..1985") is None
         assert parse_ohm_date("1984-02..2009") is None
+
+
+class TestEndOfDate:
+    def test_year_only(self):
+        assert end_of_date((2026, None, None)) == (2026, 12, 31)
+
+    def test_year_month_regular(self):
+        assert end_of_date((1971, 7, None)) == (1971, 7, 31)
+
+    def test_year_month_thirty_days(self):
+        assert end_of_date((1971, 6, None)) == (1971, 6, 30)
+
+    def test_year_month_february_leap(self):
+        assert end_of_date((1972, 2, None)) == (1972, 2, 29)
+
+    def test_year_month_february_non_leap(self):
+        assert end_of_date((1971, 2, None)) == (1971, 2, 28)
+
+    def test_year_month_day(self):
+        assert end_of_date((2026, 5, 15)) == (2026, 5, 15)
+
+    def test_negative_year(self):
+        assert end_of_date((-500, None, None)) == (-500, 12, 31)
+
+    def test_negative_year_month(self):
+        assert end_of_date((-500, 7, None)) == (-500, 7, 31)
 
 
 class TestStartOfDate:
@@ -288,6 +315,16 @@ class TestEdtfInterval:
         lo, hi = edtf_interval("1948")
         assert not (lo <= plain <= hi)
 
+    def test_year_plain_overlaps_edtf_sub_interval(self):
+        # start_date=1971 covers [1971-01-01, 1971-12-31].
+        # start_date:edtf=1971-07-02/1972-03-31 covers [1971-07-02, 1972-03-31].
+        # These overlap, so this should NOT be flagged as a mismatch.
+        plain_parsed = parse_ohm_date("1971")
+        plain_lo = start_of_date(plain_parsed)
+        plain_hi = end_of_date(plain_parsed)
+        lo, hi = edtf_interval("1971-07-02/1972-03-31")
+        assert plain_lo <= hi and lo <= plain_hi  # overlaps — no mismatch
+
 
 class TestEdtfWikiExamples:
     """Test cases drawn from the OHM wiki:
@@ -447,35 +484,41 @@ class TestEdtfWikiExamples:
 
 
 class TestIsOneDayOff:
+    """_is_one_day_off(plain_lo, plain_hi, lo, hi) — all args are DateTuples."""
+
     def test_one_day_before_lo(self):
         # The motivating case: end_date=1948-05-08, end_date:edtf=1948-05-09
+        # Both are exact days, so plain_lo == plain_hi and lo == hi.
         lo = hi = (1948, 5, 9)
-        assert _is_one_day_off((1948, 5, 8), lo, hi)
+        assert _is_one_day_off((1948, 5, 8), (1948, 5, 8), lo, hi)
 
     def test_one_day_after_hi(self):
         lo = hi = (1948, 5, 8)
-        assert _is_one_day_off((1948, 5, 9), lo, hi)
+        assert _is_one_day_off((1948, 5, 9), (1948, 5, 9), lo, hi)
 
     def test_two_days_off_is_false(self):
         lo = hi = (1948, 5, 9)
-        assert not _is_one_day_off((1948, 5, 7), lo, hi)
+        assert not _is_one_day_off((1948, 5, 7), (1948, 5, 7), lo, hi)
 
     def test_exact_match_is_false(self):
         # Inside the interval — not a mismatch at all, so not off-by-one
         lo = hi = (1948, 5, 8)
-        assert not _is_one_day_off((1948, 5, 8), lo, hi)
+        assert not _is_one_day_off((1948, 5, 8), (1948, 5, 8), lo, hi)
 
     def test_one_day_across_month_boundary(self):
         lo = hi = (1948, 6, 1)
-        assert _is_one_day_off((1948, 5, 31), lo, hi)
+        assert _is_one_day_off((1948, 5, 31), (1948, 5, 31), lo, hi)
 
     def test_one_day_across_year_boundary(self):
         lo = hi = (1949, 1, 1)
-        assert _is_one_day_off((1948, 12, 31), lo, hi)
+        assert _is_one_day_off((1948, 12, 31), (1948, 12, 31), lo, hi)
 
-    def test_interval_not_just_point(self):
-        # plain is one day before a range interval's lower bound
-        lo, hi = (1948, 5, 9), (1948, 5, 20)
-        assert _is_one_day_off((1948, 5, 8), lo, hi)
-        # plain is one day after the upper bound
-        assert _is_one_day_off((1948, 5, 21), lo, hi)
+    def test_plain_range_ends_one_day_before_edtf(self):
+        # plain=1948-05 → [1948-05-01, 1948-05-31]; edtf starts 1948-06-01
+        lo, hi = (1948, 6, 1), (1948, 6, 30)
+        assert _is_one_day_off((1948, 5, 1), (1948, 5, 31), lo, hi)
+
+    def test_plain_range_starts_one_day_after_edtf(self):
+        # plain=1948-06 → [1948-06-01, 1948-06-30]; edtf ends 1948-05-31
+        lo, hi = (1948, 5, 1), (1948, 5, 31)
+        assert _is_one_day_off((1948, 6, 1), (1948, 6, 30), lo, hi)

--- a/dates_test.py
+++ b/dates_test.py
@@ -263,3 +263,160 @@ class TestEdtfInterval:
         plain = (1949, 1, 1)
         lo, hi = edtf_interval("1948")
         assert not (lo <= plain <= hi)
+
+
+class TestEdtfWikiExamples:
+    """Test cases drawn from the OHM wiki:
+    https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Tags/Key/start_date:edtf
+    https://wiki.openstreetmap.org/wiki/OpenHistoricalMap/Tags/Key/end_date:edtf
+    Each case is a valid start_date / start_date:edtf (or end_date / end_date:edtf) pair.
+    """
+
+    # ------------------------------------------------------------------
+    # start_date:edtf examples
+    # ------------------------------------------------------------------
+
+    def test_year_only(self):
+        # "Year only" — start_date=1970, start_date:edtf=1970
+        lo, hi = edtf_interval("1970")
+        assert lo == (1970, 1, 1) and hi == (1970, 12, 31)
+        assert lo <= start_of_date(parse_ohm_date("1970")) <= hi
+
+    def test_approximate_date(self):
+        # "Approximate date" — start_date=1849, start_date:edtf=1849~
+        lo, hi = edtf_interval("1849~")
+        assert lo <= start_of_date(parse_ohm_date("1849")) <= hi
+
+    def test_uncertain_date(self):
+        # "Uncertain date" — start_date=1804, start_date:edtf=1804?
+        lo, hi = edtf_interval("1804?")
+        assert lo <= start_of_date(parse_ohm_date("1804")) <= hi
+
+    def test_date_range_interval(self):
+        # "Date range" — start_date=1908, start_date:edtf=1906/1908
+        lo, hi = edtf_interval("1906/1908")
+        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+
+    def test_date_range_set(self):
+        # "Date range" — start_date=1908, start_date:edtf=[1906..1908]
+        lo, hi = edtf_interval("[1906..1908]")
+        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+
+    def test_century_midpoint_interval(self):
+        # "Century midpoint" — start_date=1750, start_date:edtf=1730/1770
+        lo, hi = edtf_interval("1730/1770")
+        assert lo <= start_of_date(parse_ohm_date("1750")) <= hi
+
+    def test_century_midpoint_set(self):
+        # "Century midpoint" — start_date=1750, start_date:edtf=[1730..1770]
+        lo, hi = edtf_interval("[1730..1770]")
+        assert lo <= start_of_date(parse_ohm_date("1750")) <= hi
+
+    def test_decade(self):
+        # "Decade" — start_date=1895, start_date:edtf=189X
+        lo, hi = edtf_interval("189X")
+        assert lo <= start_of_date(parse_ohm_date("1895")) <= hi
+
+    def test_date_before_interval(self):
+        # "Date before" — start_date=1800, start_date:edtf=/1800
+        lo, hi = edtf_interval("/1800")
+        assert lo <= start_of_date(parse_ohm_date("1800")) <= hi
+
+    def test_date_before_set(self):
+        # "Date before" — start_date=1800, start_date:edtf=[..1800]
+        lo, hi = edtf_interval("[..1800]")
+        assert lo <= start_of_date(parse_ohm_date("1800")) <= hi
+
+    def test_early_month_range(self):
+        # "Early April 1992" — start_date=1992-04, start_date:edtf=1992-04-01/1992-04-10
+        lo, hi = edtf_interval("1992-04-01/1992-04-10")
+        assert lo <= start_of_date(parse_ohm_date("1992-04")) <= hi
+
+    def test_season_autumn(self):
+        # "Season" — start_date=1814, start_date:edtf=1814-23 (EDTF season 23 = autumn)
+        # Season codes resolve to a sub-year interval, so a year-level plain date
+        # (which maps to Jan 1 via start_of_date) falls before the autumn window.
+        # This is a known limitation of the compatibility check for season-coded EDTF.
+        lo, hi = edtf_interval("1814-23")
+        assert lo == (1814, 9, 1) and hi == (1814, 11, 30)
+
+    def test_late_season(self):
+        # "Late season" — start_date=1887, start_date:edtf=1887-39 (late autumn/winter)
+        # Same caveat as test_season_autumn: year-level plain date falls outside interval.
+        lo, hi = edtf_interval("1887-39")
+        assert lo == (1887, 9, 1) and hi == (1887, 12, 31)
+
+    def test_datetime_not_supported_start(self):
+        # "Specific date with time" — start_date:edtf=1960-05-01T13:00
+        # The edtf library does not support the datetime (T) format.
+        assert edtf_interval("1960-05-01T13:00") is None
+
+    # ------------------------------------------------------------------
+    # end_date:edtf examples
+    # ------------------------------------------------------------------
+
+    def test_year_only_end(self):
+        # "Year only" — end_date=1272, end_date:edtf=1272
+        lo, hi = edtf_interval("1272")
+        assert lo <= start_of_date(parse_ohm_date("1272")) <= hi
+
+    def test_circa(self):
+        # "circa 1871" — end_date=1871, end_date:edtf=1871~
+        lo, hi = edtf_interval("1871~")
+        assert lo <= start_of_date(parse_ohm_date("1871")) <= hi
+
+    def test_mid_century(self):
+        # "Mid sixteenth century" — end_date=1550, end_date:edtf=1550~
+        lo, hi = edtf_interval("1550~")
+        assert lo <= start_of_date(parse_ohm_date("1550")) <= hi
+
+    def test_decade_unknown_year(self):
+        # "1960s" — end_date=1960, end_date:edtf=196X
+        lo, hi = edtf_interval("196X")
+        assert lo <= start_of_date(parse_ohm_date("1960")) <= hi
+
+    def test_century_unknown_decade(self):
+        # "15th century" — end_date=1450, end_date:edtf=14XX
+        lo, hi = edtf_interval("14XX")
+        assert lo <= start_of_date(parse_ohm_date("1450")) <= hi
+
+    def test_between_dates_interval(self):
+        # "Between 1908 and 1909" — end_date=1908, end_date:edtf=1908/1909
+        lo, hi = edtf_interval("1908/1909")
+        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+
+    def test_between_dates_set(self):
+        # "Between 1908 and 1909" — end_date=1908, end_date:edtf=[1908..1909]
+        lo, hi = edtf_interval("[1908..1909]")
+        assert lo <= start_of_date(parse_ohm_date("1908")) <= hi
+
+    def test_early_period(self):
+        # "Early 1840s" — end_date=1840, end_date:edtf=1840/1845
+        lo, hi = edtf_interval("1840/1845")
+        assert lo <= start_of_date(parse_ohm_date("1840")) <= hi
+
+    def test_indefinite_end_interval(self):
+        # "On or before 2000" — end_date=2000, end_date:edtf=/2000
+        lo, hi = edtf_interval("/2000")
+        assert lo <= start_of_date(parse_ohm_date("2000")) <= hi
+
+    def test_indefinite_end_set(self):
+        # "On or before 2000" — end_date=2000, end_date:edtf=[..2000]
+        lo, hi = edtf_interval("[..2000]")
+        assert lo <= start_of_date(parse_ohm_date("2000")) <= hi
+
+    def test_as_of(self):
+        # "Building shown on 1935 map" — end_date=1935, end_date:edtf=/1935
+        lo, hi = edtf_interval("/1935")
+        assert lo <= start_of_date(parse_ohm_date("1935")) <= hi
+
+    def test_season_winter(self):
+        # "Winter of 1940" — end_date=1940, end_date:edtf=1940-24 (EDTF season 24 = winter)
+        # Same caveat as test_season_autumn: year-level plain date falls outside interval.
+        lo, hi = edtf_interval("1940-24")
+        assert lo == (1940, 12, 1) and hi == (1940, 12, 31)
+
+    def test_datetime_not_supported_end(self):
+        # "Date and time" — end_date:edtf=2011-10-04T05:00
+        # The edtf library does not support the datetime (T) format.
+        assert edtf_interval("2011-10-04T05:00") is None

--- a/dates_test.py
+++ b/dates_test.py
@@ -206,18 +206,42 @@ class TestEdtfInterval:
         assert edtf_interval("1948") == ((1948, 1, 1), (1948, 12, 31))
 
     def test_approximate_year(self):
-        # 1948~ is uncertain/approximate but still bounded to that year
+        # 1948~ uses lower_fuzzy/upper_fuzzy, which extends ~1 year in each direction
         lo, hi = edtf_interval("1948~")
-        assert lo == (1948, 1, 1)
-        assert hi == (1948, 12, 31)
+        assert lo == (1947, 1, 1)
+        assert hi == (1949, 12, 31)
 
     def test_interval(self):
         assert edtf_interval("1944/1950") == ((1944, 1, 1), (1950, 12, 31))
 
-    def test_open_ended_upper(self):
+    def test_open_ended_upper_dotdot(self):
+        # "1948/.." — explicit open end with ".."
         lo, hi = edtf_interval("1948/..")
         assert lo == (1948, 1, 1)
         assert hi == (10**12, 1, 1)
+
+    def test_open_ended_upper_bare_slash(self):
+        # "1752/" — open end written without ".."; the library returns a
+        # computed fuzzy date (~10 years out) rather than infinity, so we
+        # must override it.  end_date=1799 should be compatible.
+        lo, hi = edtf_interval("1752/")
+        assert lo == (1752, 1, 1)
+        assert hi == (10**12, 1, 1)
+        assert lo <= (1799, 1, 1) <= hi
+
+    def test_open_ended_lower_dotdot(self):
+        # "../1818" — explicit open start with ".."
+        lo, hi = edtf_interval("../1818")
+        assert lo == (-(10**12), 1, 1)
+        assert hi == (1818, 12, 31)
+
+    def test_open_ended_lower_bare_slash(self):
+        # "/1818" — open start written without ".."; same library quirk as
+        # the upper case.  start_date=1500 should be compatible.
+        lo, hi = edtf_interval("/1818")
+        assert lo == (-(10**12), 1, 1)
+        assert hi == (1818, 12, 31)
+        assert lo <= (1500, 1, 1) <= hi
 
     def test_invalid_returns_none(self):
         # Strings that are not valid EDTF at all

--- a/dates_test.py
+++ b/dates_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from chrono_stats import edtf_interval
+from chrono_stats import _is_one_day_off, edtf_interval
 from dates import (
     NEG_INF,
     POS_INF,
@@ -444,3 +444,38 @@ class TestEdtfWikiExamples:
         # "Date and time" — end_date:edtf=2011-10-04T05:00
         # The edtf library does not support the datetime (T) format.
         assert edtf_interval("2011-10-04T05:00") is None
+
+
+class TestIsOneDayOff:
+    def test_one_day_before_lo(self):
+        # The motivating case: end_date=1948-05-08, end_date:edtf=1948-05-09
+        lo = hi = (1948, 5, 9)
+        assert _is_one_day_off((1948, 5, 8), lo, hi)
+
+    def test_one_day_after_hi(self):
+        lo = hi = (1948, 5, 8)
+        assert _is_one_day_off((1948, 5, 9), lo, hi)
+
+    def test_two_days_off_is_false(self):
+        lo = hi = (1948, 5, 9)
+        assert not _is_one_day_off((1948, 5, 7), lo, hi)
+
+    def test_exact_match_is_false(self):
+        # Inside the interval — not a mismatch at all, so not off-by-one
+        lo = hi = (1948, 5, 8)
+        assert not _is_one_day_off((1948, 5, 8), lo, hi)
+
+    def test_one_day_across_month_boundary(self):
+        lo = hi = (1948, 6, 1)
+        assert _is_one_day_off((1948, 5, 31), lo, hi)
+
+    def test_one_day_across_year_boundary(self):
+        lo = hi = (1949, 1, 1)
+        assert _is_one_day_off((1948, 12, 31), lo, hi)
+
+    def test_interval_not_just_point(self):
+        # plain is one day before a range interval's lower bound
+        lo, hi = (1948, 5, 9), (1948, 5, 20)
+        assert _is_one_day_off((1948, 5, 8), lo, hi)
+        # plain is one day after the upper bound
+        assert _is_one_day_off((1948, 5, 21), lo, hi)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "ohm — project scaffolded with uv"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
+    "edtf>=5.0.1",
     "osmium>=4.3.0",
     "pyproj>=3.7.2",
     "pyright>=1.1.408",

--- a/stats-test/chronology.summary.csv
+++ b/stats-test/chronology.summary.csv
@@ -1,10 +1,10 @@
 type,count
+date-edtf-features,432
+date-edtf-invalid-dot-dot,0
+date-edtf-mismatch-off-by-one-day,299
 dated-features,1444
 dated-relations,1400
 dated-timeless,0
-edtf-features,432
-edtf-invalid-dot-dot,0
-edtf-mismatch-off-by-one-day,299
 chronology-anonymous,7
 chronology-member-outside-range,5
 chronology-overlapping-members,6

--- a/stats-test/chronology.summary.csv
+++ b/stats-test/chronology.summary.csv
@@ -1,8 +1,10 @@
 type,count
+dated-features,1444
 dated-relations,1400
 dated-timeless,0
 edtf-features,432
 edtf-invalid-dot-dot,0
+edtf-mismatch-off-by-one-day,299
 chronology-anonymous,7
 chronology-member-outside-range,5
 chronology-overlapping-members,6

--- a/stats-test/chronology.summary.csv
+++ b/stats-test/chronology.summary.csv
@@ -8,7 +8,7 @@ chronology-member-outside-range,5
 chronology-overlapping-members,6
 chronology-undated-member,5
 date-edtf-invalid,8
-date-edtf-mismatch,313
+date-edtf-mismatch,308
 date-end-no-start,68
 date-far-future,0
 date-in-name,187

--- a/stats-test/chronology.summary.csv
+++ b/stats-test/chronology.summary.csv
@@ -1,10 +1,14 @@
 type,count
-dated-relations,1397
+dated-relations,1400
 dated-timeless,0
+edtf-features,432
+edtf-invalid-dot-dot,0
 chronology-anonymous,7
 chronology-member-outside-range,5
 chronology-overlapping-members,6
 chronology-undated-member,5
+date-edtf-invalid,8
+date-edtf-mismatch,313
 date-end-no-start,68
 date-far-future,0
 date-in-name,187

--- a/stats-test/date-edtf-invalid.examples.txt
+++ b/stats-test/date-edtf-invalid.examples.txt
@@ -1,0 +1,8 @@
+n/2119122783: start_date:edtf=~981 County of Namur
+n/2147219669: end_date:edtf=1974-03-31T24:00 County of York, West Riding
+r/2809511: start_date:edtf=c13 Prince-Bishopric of Regensburg
+r/2812125: start_date:edtf=~981 County of Namur
+r/2815085: start_date:edtf=mid c10 County of Clermont-en-Argonne
+r/2840420: end_date:edtf=Lingen lost County of Tecklenburg (1400-1548)
+r/2902380: end_date:edtf=1974-03-31T24:00 Yorkshire
+w/200622259: start_date:edtf=C18 Rhine

--- a/stats-test/date-edtf-mismatch.examples.txt
+++ b/stats-test/date-edtf-mismatch.examples.txt
@@ -1,6 +1,5 @@
 n/2091745580: end_date=1806-08-12 vs end_date:edtf=1806-08-13 Dresden
 n/2094763029: end_date=1614-11-11 vs end_date:edtf=1614-11-12 Duchy of Berg
-n/2104261172: end_date=1379 vs end_date:edtf=1380~ County of Berg
 n/2104261174: end_date=1614-11-11 vs end_date:edtf=1614-11-12 County of Mark
 n/2104341367: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Luxembourg (Austria)
 n/2108636960: end_date=1766-02-22 vs end_date:edtf=1766-02-23 Duchy of Lorraine
@@ -138,14 +137,10 @@ r/2683539: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Margraviate of Baden 
 r/2693576: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Principality of Schwarzburg-Sondershausen (1697-1806)
 r/2693577: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Principality of Schwarzburg-Rudolstadt (1710-1806)
 r/2693977: end_date=1814-01-13 vs end_date:edtf=1814-01-14 Swedish Pomerania
-r/2694703: end_date=1613 vs end_date:edtf=1614~ County of Ravensberg (1346-1614)
 r/2694705: end_date=1614-11-11 vs end_date:edtf=1614-11-12 County of Mark (1521-1614)
 r/2694912: end_date=1648-05-14 vs end_date:edtf=1648-05-15 Prince-Archbishopric of Bremen (1381-1648)
 r/2695999: end_date=1807-07-06 vs end_date:edtf=1807-07-07 County of East Frisia (1600-1807)
 r/2696468: end_date=1806-03-14 vs end_date:edtf=1806-03-15 Duchy of Berg (1380-1806)
-r/2696471: end_date=1718 vs end_date:edtf=1719~ County of Ravensberg (1701-1719)
-r/2696473: end_date=1700 vs end_date:edtf=1701~ County of Ravensberg (1666-1701)
-r/2696474: end_date=1665 vs end_date:edtf=1666~ County of Ravensberg (1614-1666)
 r/2697882: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Amt Freudenberg (1582-1807)
 r/2698297: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Hohenzollern-Hechingen (1623-1806)
 r/2744511: end_date=1795-04-04 vs end_date:edtf=1795-04-05 Duchy of Cleves (1614-1795)

--- a/stats-test/date-edtf-mismatch.examples.txt
+++ b/stats-test/date-edtf-mismatch.examples.txt
@@ -1,0 +1,313 @@
+n/2091745580: end_date=1806-08-12 vs end_date:edtf=1806-08-13 Dresden
+n/2094763029: end_date=1614-11-11 vs end_date:edtf=1614-11-12 Duchy of Berg
+n/2104261172: end_date=1379 vs end_date:edtf=1380~ County of Berg
+n/2104261174: end_date=1614-11-11 vs end_date:edtf=1614-11-12 County of Mark
+n/2104341367: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Luxembourg (Austria)
+n/2108636960: end_date=1766-02-22 vs end_date:edtf=1766-02-23 Duchy of Lorraine
+n/2108765013: end_date=1805-12-31 vs end_date:edtf=1806-01-01 Electorate of Bavaria
+n/2118104232: end_date=1918-11-21 vs end_date:edtf=1918-11-22 Principality of Schwarzburg-Sondershausen
+n/2118104235: end_date=1918-11-21 vs end_date:edtf=1918-11-22 Principality of Schwarzburg-Rudolstadt
+n/2118104237: end_date=1920-04-30 vs end_date:edtf=1920-05-01 Arnstadt (Schwarzburg-Sondershausen)
+n/2118104238: end_date=1920-04-30 vs end_date:edtf=1920-05-01 Frankenhausen (Schwarzburg-Rudolstadt)
+n/2118104239: end_date=1920-04-30 vs end_date:edtf=1920-05-01 Leutenberg (Schwarzburg-Rudolstadt)
+n/2118104240: end_date=1920-04-30 vs end_date:edtf=1920-05-01 Immenrode (Schwarzburg-Rudolstadt)
+n/2118104241: end_date=1920-04-30 vs end_date:edtf=1920-05-01 Schlotheim (Schwarzburg-Rudolstadt)
+n/2118105361: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Duchy of Mecklenburg-Strelitz
+n/2118134090: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Provostry of Berchtesgaden
+n/2118134100: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Archbishopric of Salzburg
+n/2118137736: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Principality of Hohenzollern-Hechingen
+n/2118145420: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Freising
+n/2118145421: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Grafschaft Werdenfels (Hochstift Freising)
+n/2118153454: end_date=1806-08-12 vs end_date:edtf=1806-08-13 Landgraviate of Hesse-Darmstadt
+n/2118153455: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Landgraviate of Hesse-Kassel
+n/2118153460: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Electorate of Saxony
+n/2118159024: end_date=1806-03-14 vs end_date:edtf=1806-03-15 County of Gimborn
+n/2118160117: end_date=1802-07-31 vs end_date:edtf=1802-08-01 Prince-Bishopric of Paderborn
+n/2118160354: end_date=1807-07-06 vs end_date:edtf=1807-07-07 County of Rietberg
+n/2118165979: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Hildesheim
+n/2118179986: end_date=1701-01-17 vs end_date:edtf=1701-01-18 Principality of Minden (to Electorate of Brandenburg)
+n/2118179987: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Principality of Minden (to Kingdom of Prussia)
+n/2118180939: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Herrschaft Schmalkalden (Hessen-Cassel)
+n/2118181436: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Münster
+n/2118182115: end_date=1720-01-20 vs end_date:edtf=1720-01-21 Swedish Pomerania
+n/2118221793: end_date=1807-07-06 vs end_date:edtf=1807-07-07 County of Diepholz
+n/2118311555: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Lordship of Cottbus
+n/2118367336: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Duchy of Anhalt-Köthen
+n/2118367338: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Duchy of Anhalt-Bernburg
+n/2118367340: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Duchy of Anhalt-Bernburg
+n/2118367341: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Duchy of Anhalt-Dessau
+n/2118367343: end_date=1793-03-02 vs end_date:edtf=1793-03-03 Principality of Anhalt-Zerbst
+n/2118439207: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Standesherrschaft Baruth
+n/2118439208: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Standesherrschaft Sonnewalde
+n/2118439219: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Amt Dahme
+n/2118439220: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Amt Jüterbog
+n/2118439487: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Amt Belzig
+n/2118496042: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Altmark
+n/2118568087: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishipric of Fulda
+n/2118568751: end_date=1812-12-23 vs end_date:edtf=1812-12-24 Principality of Anhalt-Bernburg-Schaumburg-Hoym
+n/2118568753: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Anhalt-Dessauischen Amt Alsleben (preußische Landeshoheit)
+n/2118569875: end_date=1807-07-08 vs end_date:edtf=1807-07-09 Herrschaft Jever (Russland)
+n/2118569876: end_date=1793-03-02 vs end_date:edtf=1793-03-03 Herrschaft Jever (Anhalt-Zerbst)
+n/2118569877: end_date=1807-07-08 vs end_date:edtf=1807-07-09 County of East Frisia (Kingdom of Prussia)
+n/2118569878: end_date=1744-05-24 vs end_date:edtf=1744-05-25 County of East Frisia
+n/2118576721: end_date=1807-07-08 vs end_date:edtf=1807-07-09 Principality of Hildesheim (Kd. Prussia)
+n/2118576722: end_date=1618-08-26 vs end_date:edtf=1618-08-27 Duchy of Cleves (Brandenburg)
+n/2118576723: end_date=1701-01-17 vs end_date:edtf=1701-01-18 Duchy of Cleves (Brandenburg-Prussia)
+n/2118576726: end_date=1618-08-26 vs end_date:edtf=1618-08-27 County of Mark (Brandenburg)
+n/2118576758: end_date=1701-01-17 vs end_date:edtf=1701-01-18 County of Mark (Brandenburg-Prussia)
+n/2118589692: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Paderborn (Prussian occupation)
+n/2118631212: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Princely Abbey of Stavelot-Malmedy
+n/2118633091: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Hochbank Spirmont (Limburg)
+n/2118633258: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Limburg (Austria)
+n/2119120054: end_date=1678-09-16 vs end_date:edtf=1678-09-17 Free County of Burgundy (Spain)
+n/2119120055: end_date=1556-01-15 vs end_date:edtf=1556-01-16 Free County of Burgundy (Habsburg)
+n/2119122783: end_date=1556-01-15 vs end_date:edtf=1556-01-16 County of Namur
+n/2119122784: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Namur (Austria)
+n/2119122788: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Brabant (Austria)
+n/2119122791: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Hainaut (Austria)
+n/2119122792: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Flanders (Austria)
+n/2119123002: end_date=1800-12-31 vs end_date:edtf=1801-01-01 Electorate of Hanover (Great Britain)
+n/2119123003: end_date=1805-12-14 vs end_date:edtf=1805-12-15 Electorate of Hanover (United Kingdom)
+n/2125021252: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Neustädtischer Kreis
+n/2125021253: end_date=1835-04-30 vs end_date:edtf=1835-05-01 Vogtländischer Kreis
+n/2125039435: end_date=1806-04-14 vs end_date:edtf=1806-04-15 Imperial Lordship of Bonndorf (Abbey of Saint Blaise)
+n/2125071883: end_date=1604-08-28 vs end_date:edtf=1604-08-29 Principality of Palatinate-Sulzbach
+n/2125071884: end_date=1742-12-30 vs end_date:edtf=1742-12-31 Principality of Pfalz-Sulzbach
+n/2125097285: end_date=1806-07-11 vs end_date:edtf=1806-07-12 Principality of Sayn-Wittgenstein-Hohenstein
+n/2125097286: end_date=1741-07-25 vs end_date:edtf=1741-07-26 County of Sayn-W.-S.-Altenkirchen
+n/2125105757: end_date=1808-06-20 vs end_date:edtf=1808-06-21 Hft. Hohenwaldeck
+n/2125105758: end_date=1808-06-20 vs end_date:edtf=1808-06-21 Hft. Türkheim (Churbaiern)
+n/2125105759: end_date=1808-06-20 vs end_date:edtf=1808-06-21 Hft. Mindelheim (Churbaiern)
+n/2125147232: end_date=1597-09-29 vs end_date:edtf=1597-09-30 Immenrode (Schwarzburg-Frankenhausen)
+n/2125147233: end_date=1597-09-29 vs end_date:edtf=1597-09-30 Schlotheim (Schwarzburg-Frankenhausen)
+n/2125147234: end_date=1597-09-29 vs end_date:edtf=1597-09-30 Gft. Schwarzburg-Frankenhausen
+n/2125157979: end_date=1806-08-12 vs end_date:edtf=1806-08-13 Landgraviate of Hesse-Darmstadt
+n/2125184544: end_date=1806-08-29 vs end_date:edtf=1806-08-30 Principality of Nassau-Weilburg
+n/2125221077: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Lordship of Kirchheim (Nassau-Weilburg)
+n/2125221193: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Margraviate of Baden
+n/2125221194: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Lordship of Grafenstein (Baden)
+n/2125233168: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Austrian Upper Guelders
+n/2125233169: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Austrian Upper Guelders
+n/2125255768: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Landgrafschaft Hessen-Rotenburg (Hessen-Cassel)
+n/2125278446: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Österreichisch-Obergeldern
+n/2125286470: end_date=1678-09-16 vs end_date:edtf=1678-09-17 Cambrésis (España)
+n/2125288770: end_date=1648-10-23 vs end_date:edtf=1648-10-24 Sundgau
+n/2125335163: end_date=1791-01-23 vs end_date:edtf=1791-01-24 Grafschaft Lützelstein (Pfalz-Zweibrücken)
+n/2125335672: end_date=1766-02-22 vs end_date:edtf=1766-02-23 County of Saarwerden (Nassau-Saarbrücken)
+n/2125335799: end_date=1723-12-05 vs end_date:edtf=1723-12-06 Gft. Nassau-Saarbrücken
+n/2125349553: end_date=1673-07-17 vs end_date:edtf=1673-07-18 County of Rappoltstein/Ribeaupierre
+n/2125349554: end_date=1791-09-20 vs end_date:edtf=1791-09-21 Grafschaft Rappoltstein (Pfalz-Zweibrücken)
+n/2125375002: end_date=1777-12-29 vs end_date:edtf=1777-12-30 Duchy of Berg (Electoral Palatinate)
+n/2125381841: end_date=1556-01-15 vs end_date:edtf=1556-01-16 Duchy of Guelders
+n/2125381842: end_date=1393-12-12 vs end_date:edtf=1393-12-13 Duchy of Guelders
+n/2125381845: end_date=1423-06-24 vs end_date:edtf=1423-06-25 Duchy of Guelders
+n/2125381846: end_date=1581-07-25 vs end_date:edtf=1581-07-26 Duchy of Guelders
+n/2125381848: end_date=1581-07-25 vs end_date:edtf=1581-07-26 Lordship of Overijssel
+n/2125381852: end_date=1581-07-25 vs end_date:edtf=1581-07-26 Lordship of Utrecht
+n/2125381853: end_date=1795-01-17 vs end_date:edtf=1795-01-18 Utrecht
+n/2125392419: end_date=1581-07-25 vs end_date:edtf=1581-07-26 Lordship of Drenthe
+n/2125429008: end_date=1554-02-23 vs end_date:edtf=1554-02-24 Duchy of Saxony
+n/2125429145: end_date=1554-02-23 vs end_date:edtf=1554-02-24 Duchy of Saxony
+n/2125532669: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Speyer
+n/2125542283: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Margraviate of Baden-Durlach
+n/2125542284: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Margraviate of Baden-Baden
+n/2125543529: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Lower County of Sponheim (Baden-Baden)
+n/2125543530: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Upper County of Sponheim (Baden-Baden)
+n/2125555936: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Upper County of Sponheim (Baden)
+n/2125555937: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Upper County of Sponheim (Baden-Baden)
+n/2125555939: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Lower County of Sponheim (Baden)
+n/2125555941: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Lower County of Sponheim (Baden)
+n/2125555943: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Upper County of Sponheim (Baden)
+n/2125555944: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Upper County of Sponheim (Baden)
+n/2125555947: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Upper County of Sponheim (Baden-Baden)
+n/2125555948: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Lower County of Sponheim (Baden-Baden)
+n/2125590005: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Palatinate-Zweibrücken
+n/2125648100: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Lordship of Grafenstein (Baden-Baden)
+n/2125649595: end_date=1712-01-05 vs end_date:edtf=1712-01-06 Imperial County of Waldeck
+n/2125922417: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Lübeck
+n/2125922418: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Lübeck
+n/2125922419: end_date=1810-07-08 vs end_date:edtf=1810-07-09 Principality of Lübeck (Oldenburg)
+n/2125922420: end_date=1810-07-08 vs end_date:edtf=1810-07-09 Principality of Lübeck (Oldenburg)
+n/2126415899: end_date=1556-01-15 vs end_date:edtf=1556-01-16 County of Lingen (Habsburg)
+n/2126415900: end_date=1556-01-15 vs end_date:edtf=1556-01-16 County of Lingen (Habsburg)
+n/2126415904: end_date=1702-03-18 vs end_date:edtf=1702-03-19 County of Lingen (Nassau-Orange)
+n/2126415908: end_date=1702-03-18 vs end_date:edtf=1702-03-19 County of Lingen (Nassau-Orange)
+n/2130398958: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Passau
+r/2661252: end_date=1806-07-11 vs end_date:edtf=1806-07-12 County of Hohengeroldseck (1711-1806)
+r/2683539: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Margraviate of Baden (1771-1797)
+r/2693576: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Principality of Schwarzburg-Sondershausen (1697-1806)
+r/2693577: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Principality of Schwarzburg-Rudolstadt (1710-1806)
+r/2693977: end_date=1814-01-13 vs end_date:edtf=1814-01-14 Swedish Pomerania
+r/2694703: end_date=1613 vs end_date:edtf=1614~ County of Ravensberg (1346-1614)
+r/2694705: end_date=1614-11-11 vs end_date:edtf=1614-11-12 County of Mark (1521-1614)
+r/2694912: end_date=1648-05-14 vs end_date:edtf=1648-05-15 Prince-Archbishopric of Bremen (1381-1648)
+r/2695999: end_date=1807-07-06 vs end_date:edtf=1807-07-07 County of East Frisia (1600-1807)
+r/2696468: end_date=1806-03-14 vs end_date:edtf=1806-03-15 Duchy of Berg (1380-1806)
+r/2696471: end_date=1718 vs end_date:edtf=1719~ County of Ravensberg (1701-1719)
+r/2696473: end_date=1700 vs end_date:edtf=1701~ County of Ravensberg (1666-1701)
+r/2696474: end_date=1665 vs end_date:edtf=1666~ County of Ravensberg (1614-1666)
+r/2697882: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Amt Freudenberg (1582-1807)
+r/2698297: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Hohenzollern-Hechingen (1623-1806)
+r/2744511: end_date=1795-04-04 vs end_date:edtf=1795-04-05 Duchy of Cleves (1614-1795)
+r/2748501: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Luxembourg (1769-1797)
+r/2804283: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Duchy of Carniola
+r/2806819: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Provostry of Berchtesgaden
+r/2806820: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Archbishopric of Salzburg (1565-1803)
+r/2806961: end_date=1806-03-14 vs end_date:edtf=1806-03-15 County of Gimborn (1631-1806)
+r/2806963: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Paderborn
+r/2806964: end_date=1807-07-06 vs end_date:edtf=1807-07-07 County of Rietberg
+r/2806976: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Hildesheim (1623-1803)
+r/2806988: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Hesse-Kassel (1736-1797)
+r/2807022: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Principality of Minden
+r/2807026: end_date=1805-12-14 vs end_date:edtf=1805-12-15 Hanover (1803-1805)
+r/2807027: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Hanover (1733-1803)
+r/2807028: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Herrschaft Schmalkalden (1583-1807)
+r/2807030: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Münster (1654-1803)
+r/2807242: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Duchy of Saxe-Lauenburg (1689-1807)
+r/2807493: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Neustädtischer Kreis (1660-1815)
+r/2807589: end_date=1807-07-06 vs end_date:edtf=1807-07-07 County of Diepholz (1585-1807)
+r/2808062: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Lordship of Cottbus
+r/2808135: end_date=1806-12-10 vs end_date:edtf=1806-12-11 Electoral Circle (1746-1806)
+r/2808388: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Lordship of Baruth
+r/2808389: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Lordship of Sonnewalde
+r/2808390: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Amt Dahme
+r/2808391: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Amt Jüterbog
+r/2808392: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Amt Belzig
+r/2808493: end_date=1807-07-08 vs end_date:edtf=1807-07-09 Altmark (1318-1807)
+r/2808803: end_date=1648-10-23 vs end_date:edtf=1648-10-24 Herrschaft Blumenegg (1391-1648)
+r/2809488: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Dortmund
+r/2809505: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Passau
+r/2809510: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Regensburg
+r/2809511: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Regensburg
+r/2809680: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Fulda
+r/2809681: end_date=1752-10-04 vs end_date:edtf=1752-10-05 Princely Abbey of Fulda
+r/2809685: end_date=1793-03-02 vs end_date:edtf=1793-03-03 Principality of Anhalt-Bernburg (1603-1793)
+r/2809686: end_date=1793-03-02 vs end_date:edtf=1793-03-03 Principality of Anhalt-Köthen (1603-1793)
+r/2809694: end_date=1812-12-23 vs end_date:edtf=1812-12-24 Anhalt-Bernburg-Schaumburg-Hoym
+r/2809696: end_date=1807-07-06 vs end_date:edtf=1807-07-07 Amt Alsleben
+r/2809702: end_date=1807-07-08 vs end_date:edtf=1807-07-09 Herrschaft Jever (1667-1807)
+r/2809746: end_date=1807-07-08 vs end_date:edtf=1807-07-09 Principality of Hildesheim
+r/2809747: end_date=1807-07-08 vs end_date:edtf=1807-07-09 County of Mark (1631-1807)
+r/2809748: end_date=1521-03-14 vs end_date:edtf=1521-03-15 County of Mark (1449-1521)
+r/2810078: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Princely Abbey of Stavelot-Malmedy
+r/2810096: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Limburg (1648-1797)
+r/2810172: end_date=1678-09-16 vs end_date:edtf=1678-09-17 Burgundian Circle (1659-1678)
+r/2810173: end_date=1797-10-17 vs end_date:edtf=1797-10-16 Burgundian Circle (1769-1797)
+r/2810174: end_date=1779-05-12 vs end_date:edtf=1779-05-13 Bavarian Circle (1565-1779)
+r/2810435: end_date=1798-12-12 vs end_date:edtf=1798-12-13 French Republic (1798 01-12)
+r/2810439: end_date=1738-11-22 vs end_date:edtf=1738-11-23 Wild- and Rhinegraviate of Salm-Salm
+r/2810440: end_date=1797-02-18 vs end_date:edtf=1797-02-19 Principality of Salm-Salm
+r/2810446: end_date=1792-11-25 vs end_date:edtf=1792-11-26 Duchy of Savoy (1601-1792)
+r/2812123: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Lower Rhenish–Westphalian Circle (1548-1679)
+r/2812125: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Namur
+r/2812126: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Duchy of Brabant (1648-1797)
+r/2812127: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Flanders (1659-1797)
+r/2812128: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Hainaut (1659-1797)
+r/2815083: end_date=1661-02-27 vs end_date:edtf=1661-02-28 Barrois non mouvant (1301-1661)
+r/2815329: end_date=1661-02-27 vs end_date:edtf=1661-02-28 Duchy of Lorraine (?-1661)
+r/2815331: end_date=1766-02-22 vs end_date:edtf=1766-02-23 Barrois non mouvant (1718-1766)
+r/2815357: end_date=1697-09-19 vs end_date:edtf=1697-09-20 Barrois non mouvant (1661-1697)
+r/2815358: end_date=1697-09-19 vs end_date:edtf=1697-09-20 Duchy of Lorraine (1661-1697)
+r/2815359: end_date=1766-02-22 vs end_date:edtf=1766-02-23 Duchy of Lorraine (1718-1766)
+r/2830392: end_date=1742-07-27 vs end_date:edtf=1742-07-28 Lands of the Bohemian Crown (1635-1742)
+r/2830427: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Vogtländischer Kreis (1577-1815)
+r/2830429: end_date=1742-07-27 vs end_date:edtf=1742-07-28 Bohemia (1557-1742)
+r/2830430: end_date=1635-05-29 vs end_date:edtf=1635-05-30 Lands of the Bohemian Crown (1557-1635)
+r/2830431: end_date=1718-11-14 vs end_date:edtf=1718-11-15 Duchy of Saxe-Zeitz
+r/2830453: end_date=1806-04-14 vs end_date:edtf=1806-04-15 Reichsherrschaft Bonndorf
+r/2830460: end_date=1827-01-05 vs end_date:edtf=1827-01-06 County of Sayn-Hachenburg
+r/2830462: end_date=1803-04-26 vs end_date:edtf=1803-04-27 County of Sayn-Altenkirchen
+r/2830504: end_date=1742-07-27 vs end_date:edtf=1742-07-28 Moravia (1182-1742)
+r/2830505: end_date=1604-08-28 vs end_date:edtf=1604-08-29 Principality of Palatinate-Sulzbach (1569-1604)
+r/2830506: end_date=1742-12-30 vs end_date:edtf=1742-12-31 Principality of Palatinate-Sulzbach (1614-1742)
+r/2830563: end_date=1806-07-11 vs end_date:edtf=1806-07-12 Sayn-Wittgenstein-Hohenstein
+r/2830564: end_date=1810-02-15 vs end_date:edtf=1810-02-16 Hesse-Hanau (1760-1810)
+r/2830571: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Princely Abbey of Kempten (1289-1803)
+r/2830572: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Imperial Abbey of Irsee
+r/2830573: end_date=1624 vs end_date:edtf=1803-04-27 Imperial Abbey of Ottobeuren (1299-1624)
+r/2830574: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Imperial Abbey of Ottobeuren (1710-1803)
+r/2830576: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Kempten
+r/2830577: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Kaufbeuren
+r/2830580: end_date=1808-06-20 vs end_date:edtf=1808-06-21 Lordship of Hohenwaldeck
+r/2830581: end_date=1808-06-20 vs end_date:edtf=1808-06-21 Herrschaft Türkheim
+r/2830582: end_date=1808-06-20 vs end_date:edtf=1808-06-21 Herrschaft Mindelheim
+r/2830583: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Augsburg
+r/2830590: end_date=1705-03-19 vs end_date:edtf=1705-03-20 Electorate of Bavaria (1663-1705)
+r/2830593: end_date=1779-05-12 vs end_date:edtf=1779-05-13 Electorate of Bavaria (1764-1779)
+r/2830619: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Wetzlar
+r/2830659: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Mühlhausen
+r/2830672: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Nordhausen
+r/2830684: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Upper Saxon Circle (1593-1806)
+r/2830685: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Lower Saxon Circle (1593-1806)
+r/2830687: end_date=1597-09-29 vs end_date:edtf=1597-09-30 County of Schwarzburg-Frankenhausen
+r/2830688: end_date=1597-09-29 vs end_date:edtf=1597-09-30 County of Schwarzburg-Rudolstadt (1571-1597)
+r/2830709: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Hesse-Darmstadt (1736-1797)
+r/2830710: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Free Imperial City of Speyer
+r/2830712: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Friedberg
+r/2830736: end_date=1797-10-09 vs end_date:edtf=1797-10-10 Prince-Bishopric of Worms
+r/2830737: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Worms
+r/2830776: end_date=1723-12-05 vs end_date:edtf=1723-12-06 County of Nassau-Saarbrücken (1651-1723)
+r/2830777: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Leiningen
+r/2830781: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Weissenburg
+r/2830782: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Landau
+r/2830880: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Margraviate of Baden (1797-1803)
+r/2830916: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Austrian Upper Guelders
+r/2830968: end_date=1815-06-08 vs end_date:edtf=1815-06-09 Vogtei Kreuzberg
+r/2830970: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Landgraviate of Hesse-Rotenburg (1627-1797)
+r/2830971: end_date=1736-03-27 vs end_date:edtf=1736-03-28 Hesse-Kassel (1648-1736)
+r/2830972: end_date=1648-10-23 vs end_date:edtf=1648-10-24 Hesse-Kassel (1640-1648)
+r/2830973: end_date=1648-10-23 vs end_date:edtf=1648-10-24 Imperial Abbey of Hersfeld
+r/2831006: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Imperial Abbey of Essen
+r/2831007: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Imperial Abbey of Werden
+r/2831008: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Free Imperial City of Cologne
+r/2831009: end_date=1795-04-05 vs end_date:edtf=1795-04-04 County of Moers
+r/2831013: end_date=1713-04-01 vs end_date:edtf=1713-04-02 Lower Rhenish–Westphalian Circle (1679-1713)
+r/2831130: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Imperial Abbey of Thorn
+r/2831136: end_date=1785-11-07 vs end_date:edtf=1785-11-08 County of Dalhem (Habsburg, 1661-1785)
+r/2831138: end_date=1785-11-07 vs end_date:edtf=1785-11-08 Landen van Overmaas (1661-1785)
+r/2831139: end_date=1785-11-07 vs end_date:edtf=1785-11-08 's-Hertogenrode (1661-1785)
+r/2831140: end_date=1785-11-07 vs end_date:edtf=1785-11-08 Land van Valkenburg (1661-1785)
+r/2831144: end_date=1678-09-16 vs end_date:edtf=1678-09-17 Cambrésis (948-1678)
+r/2831155: end_date=1798-01-27 vs end_date:edtf=1798-01-28 Republic of Mulhouse
+r/2831156: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Munster
+r/2831157: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Colmar
+r/2831158: end_date=1648-10-23 vs end_date:edtf=1648-10-24 Sundgau (13c.-1648)
+r/2831159: end_date=1648-05-14 vs end_date:edtf=1648-05-15 Austrian Circle (1618-1648)
+r/2831172: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Schlettstadt
+r/2831223: end_date=1681-09-29 vs end_date:edtf=1681-09-30 Free Imperial City of Strasbourg
+r/2831258: end_date=1791-01-23 vs end_date:edtf=1791-01-24 County of Lützelstein
+r/2831333: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Kaysersberg
+r/2831334: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Turckheim
+r/2831336: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Rosheim
+r/2831337: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Obernai
+r/2831375: end_date=1791-09-13 vs end_date:edtf=1791-09-14 County of Rappoltstein
+r/2831381: end_date=1679-02-04 vs end_date:edtf=1679-02-05 Free Imperial City of Hagenau
+r/2831618: end_date=1581-07-25 vs end_date:edtf=1581-07-26 Duchy of Guelders
+r/2831685: end_date=1536-08-04 vs end_date:edtf=1536-08-05 County of Drenthe
+r/2831691: end_date=1548-06-25 vs end_date:edtf=1548-06-26 Lower Rhenish–Westphalian Circle (1500-1548)
+r/2831954: end_date=1815-06-08 vs end_date:edtf=1815-06-09 County of (Upper) Schönburg
+r/2832004: end_date=1554-02-23 vs end_date:edtf=1554-02-24 Duchy of Saxony (1547-1554)
+r/2832638: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Esslingen
+r/2832639: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Weil
+r/2832640: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Heilbronn
+r/2832641: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Reutlingen
+r/2832689: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Ulm
+r/2832706: end_date=1360-12-02 vs end_date:edtf=1360-12-03 Free Imperial City of Gmünd (1250-1360)
+r/2832713: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Dinkelsbühl
+r/2832714: end_date=1806-08-05 vs end_date:edtf=1806-08-06 Swabian Circle
+r/2832737: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Prince-Bishopric of Speyer (1697-1797)
+r/2832827: end_date=1803-03-24 vs end_date:edtf=1803-04-27 Free Imperial City of Rottweil
+r/2832841: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Sponheim (1437-1797)
+r/2832842: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Rhinegraviate
+r/2832926: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Lordship of Reipoltskirchen
+r/2833825: end_date=1797-10-16 vs end_date:edtf=1797-10-17 County of Blieskastel
+r/2834738: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Margraviate of Baden-Durlach
+r/2834739: end_date=1771-10-20 vs end_date:edtf=1771-10-21 Margraviate of Baden-Baden
+r/2834849: end_date=1712-01-05 vs end_date:edtf=1712-01-06 Waldeck (1526-1712)
+r/2835925: end_date=1803-04-26 vs end_date:edtf=1803-04-27 Prince-Bishopric of Lübeck
+r/2835926: end_date=1810-07-08 vs end_date:edtf=1810-07-09 Principality of Lübeck (1803-1810)
+r/2839759: end_date=1678-09-16 vs end_date:edtf=1678-09-17 Free County of Burgundy (1654-1678)
+r/2840436: end_date=1806-07-11 vs end_date:edtf=1806-07-12 County of Steinfurt
+r/2852002: end_date=1797-10-16 vs end_date:edtf=1797-10-17 Free Imperial City of Aachen
+r/2853878: end_date=1713-04-10 vs end_date:edtf=1713-04-11 Upper Rhenish Circle
+w/199296850: start_date=1916 vs start_date:edtf=1945/1953 

--- a/uv.lock
+++ b/uv.lock
@@ -86,6 +86,18 @@ wheels = [
 ]
 
 [[package]]
+name = "edtf"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/23/e9f69255f67f55b03e2705bfd7a579a01c26146b9ea98f9cdb07d8156b4d/edtf-5.0.1-py3-none-any.whl", hash = "sha256:d3ed8c1307330d7563ae9efc4193988acddeb60dcfb740d4fe0abe739ef0944a", size = 36776 },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -178,6 +190,7 @@ name = "ohm"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "edtf" },
     { name = "osmium" },
     { name = "pyproj" },
     { name = "pyright" },
@@ -193,6 +206,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "edtf", specifier = ">=5.0.1" },
     { name = "osmium", specifier = ">=4.3.0" },
     { name = "pyproj", specifier = ">=3.7.2" },
     { name = "pyright", specifier = ">=1.1.408" },
@@ -272,6 +286,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781 },
 ]
 
 [[package]]
@@ -357,6 +380,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
 ]
 
 [[package]]
@@ -448,6 +483,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511 },
     { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607 },
     { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #32

Stats for 2026-04-19:

```
dated-features,3131906
date-edtf-features,868741
date-edtf-invalid-dot-dot,28746
date-edtf-mismatch-off-by-one-day,1895
date-edtf-invalid,39421
date-edtf-mismatch,3192
```

## What this does

Adds validation checks for `start_date:edtf` / `end_date:edtf` tags against their plain `start_date` / `end_date` counterparts, surfaced as new rows in the chronology dashboard.

### New stat categories

- **`date-edtf-invalid`** — `start_date:edtf` or `end_date:edtf` values that are not parseable as valid EDTF. Examples are written to `date-edtf-invalid.examples.txt`.
- **`date-edtf-mismatch`** — features where the plain date and the EDTF date don't overlap (see below for the overlap logic). Examples in `date-edtf-mismatch.examples.txt`.

### New summary counters

- **`date-edtf-features`** — total features carrying at least one EDTF tag.
- **`date-edtf-invalid-dot-dot`** — invalid EDTF values of the form `1970..1977`, `..1970`, or `1970..` (OHM-style ranges using `..` instead of the EDTF separator `/`). Reported as a fraction of `date-edtf-invalid` to show how many bad values could be auto-corrected.
- **`date-edtf-mismatch-off-by-one-day`** — mismatch cases where the plain date and the EDTF date differ by exactly one day (e.g. `end_date=1948-05-08` vs `end_date:edtf=1948-05-09`).

### Overlap-based compatibility check

Both the plain date and the EDTF value represent an interval, not a point. `start_date=1971` means "sometime in 1971" (i.e. [1971-01-01, 1971-12-31]), not just Jan 1. The mismatch check uses interval overlap rather than point containment, so `start_date=1971` vs `start_date:edtf=1971-07-02/1972-03-31` is correctly accepted.

`end_of_date()` was added to `dates.py` (the symmetric counterpart to `start_of_date()`) to compute the upper bound of a partial date.

### Correctness fixes in `edtf_interval()`

- **Open-ended bare-slash intervals** (`1752/`, `/1818`): the library resolves the open end to a computed fuzzy date (~10 years out) rather than infinity. Detected via `UnspecifiedIntervalSection` with an empty string and overridden to the correct infinite bound.
- **Partially-unspecified month/day digits** (`1X00-1X-1X`): parses successfully but `lower_strict()` / `upper_strict()` raise `ValueError`. Now caught and returned as `None` (treated as invalid EDTF).

### Performance

The EDTF parser (pyparsing-based) takes ~2 ms per call. Profiling showed it consumed 93% of runtime. `edtf_interval()` is now memoized with `@functools.lru_cache`, reducing repeated parses of the same EDTF string to a dict lookup.