### PR TITLE
Track EDTF dates without plain dates

### DIFF
--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -136,6 +136,7 @@ class DateExtractor(osmium.SimpleHandler):
         self.n_dot_dot_edtf = 0
         self.edtf_mismatch = []
         self.n_edtf_off_by_one = 0
+        self.edtf_without_plain = []
 
     def handle_object(self, typ: str, f: OSMObject):
         name = f.tags.get("name")
@@ -200,6 +201,11 @@ class DateExtractor(osmium.SimpleHandler):
             if not edtf_str:
                 continue
             has_edtf = True
+            if not plain:
+                self.edtf_without_plain.append(
+                    (typ, f.id, f"{edtf_tag}={edtf_str} {name}")
+                )
+                continue
             interval = edtf_interval(edtf_str)
             if interval is None:
                 self.invalid_edtf.append((typ, f.id, f"{edtf_tag}={edtf_str} {name}"))
@@ -381,6 +387,7 @@ def main() -> None:
         "date-end-no-start": [(typ, id, "") for typ, id in handler.end_no_start],
         "date-start-after-end": handler.start_after_end,
         "date-far-future": handler.far_future,
+        "date-edtf-without-plain": handler.edtf_without_plain,
         "date-edtf-invalid": handler.invalid_edtf,
         "date-edtf-mismatch": handler.edtf_mismatch,
         "chronology-anonymous": ch.anonymous_chronologies,

--- a/stats-test/chronology.summary.csv
+++ b/stats-test/chronology.summary.csv
@@ -11,6 +11,7 @@ chronology-overlapping-members,6
 chronology-undated-member,5
 date-edtf-invalid,8
 date-edtf-mismatch,308
+date-edtf-without-plain,10
 date-end-no-start,68
 date-far-future,0
 date-in-name,187

--- a/stats-test/date-edtf-without-plain.examples.txt
+++ b/stats-test/date-edtf-without-plain.examples.txt
@@ -1,0 +1,10 @@
+w/199292885: end_date:edtf=1946/1953 
+w/199296048: end_date:edtf=1966/1969 Academy Boulevard
+w/199296049: end_date:edtf=1966/1969 Academy Boulevard
+w/199296050: end_date:edtf=1966/1969 Academy Boulevard
+w/199296051: end_date:edtf=1966/1969 Academy Boulevard
+w/199296052: end_date:edtf=1966/1969 Academy Boulevard
+w/199296053: end_date:edtf=1966/1969 Academy Boulevard
+w/200162370: end_date:edtf=1952/ 
+w/200550792: end_date:edtf=[1877..1887] 
+w/200570774: start_date:edtf=/1925 


### PR DESCRIPTION
There are currently 5,810 of these.