### PR TITLE
More EDTF fallbacks

### DIFF
--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -26,6 +26,31 @@ NAME_RANGE_PAT = r"\(-?\d{3,}--?\d{3,}\)"
 # Matches OHM-style ranges written with ".." instead of the EDTF separator "/":
 # "1970..1977", "..1970", "1970.."
 DOT_DOT_EDTF_PAT = re.compile(r"^(-?\d[\d-]*)?\.\.(-?\d[\d-]*)?$")
+# Matches EDTF set-consecutive notation with month or day components:
+# "[2018-07..2019-02]", "[1628-06-23..1628-09-03]"
+# The edtf library handles "[YYYY..YYYY]" but fails on month/day variants.
+SET_CONSECUTIVE_PAT = re.compile(
+    r"^\[(-?\d{4})(-\d{2})?(-\d{2})?\.\.(-?\d{4})(-\d{2})?(-\d{2})?\]$"
+)
+
+
+def _parse_set_consecutive(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
+    """Parse EDTF set-consecutive notation like [2018-07..2019-02] that the library rejects."""
+    m = SET_CONSECUTIVE_PAT.match(edtf_str)
+    if not m:
+        return None
+    lo_year, lo_month_s, lo_day_s, hi_year, hi_month_s, hi_day_s = m.groups()
+    lo_parsed = (
+        int(lo_year),
+        int(lo_month_s[1:]) if lo_month_s else None,
+        int(lo_day_s[1:]) if lo_day_s else None,
+    )
+    hi_parsed = (
+        int(hi_year),
+        int(hi_month_s[1:]) if hi_month_s else None,
+        int(hi_day_s[1:]) if hi_day_s else None,
+    )
+    return start_of_date(lo_parsed), end_of_date(hi_parsed)
 
 
 @functools.lru_cache(maxsize=None)
@@ -40,7 +65,7 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
         lo = parsed.lower_fuzzy()  # type: ignore[attr-defined]
         hi = parsed.upper_fuzzy()  # type: ignore[attr-defined]
     except Exception:
-        return None
+        return _parse_set_consecutive(edtf_str)
     # "1752/" and "/1818" use an empty UnspecifiedIntervalSection for the open
     # end.  The library resolves this to a computed fuzzy date (~10 years out)
     # instead of infinity.  Detect and override to the correct infinite bound.

--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -32,6 +32,9 @@ DOT_DOT_EDTF_PAT = re.compile(r"^(-?\d[\d-]*)?\.\.(-?\d[\d-]*)?$")
 SET_CONSECUTIVE_PAT = re.compile(
     r"^\[(-?\d{4})(-\d{2})?(-\d{2})?\.\.(-?\d{4})(-\d{2})?(-\d{2})?\]$"
 )
+# Matches datetime strings missing seconds: "2007-11-04T02:00-05:00"
+# The edtf library requires seconds in datetime strings.
+DATETIME_NO_SECONDS_PAT = re.compile(r"^(-?\d{4}-\d{2}-\d{2}T\d{2}:\d{2})([-+Z].*)$")
 
 
 def _parse_set_consecutive(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
@@ -65,7 +68,12 @@ def edtf_interval(edtf_str: str) -> tuple[DateTuple, DateTuple] | None:
         lo = parsed.lower_fuzzy()  # type: ignore[attr-defined]
         hi = parsed.upper_fuzzy()  # type: ignore[attr-defined]
     except Exception:
-        return _parse_set_consecutive(edtf_str)
+        if result := _parse_set_consecutive(edtf_str):
+            return result
+        m = DATETIME_NO_SECONDS_PAT.match(edtf_str)
+        if m:
+            return edtf_interval(m.group(1) + ":00" + m.group(2))
+        return None
     # "1752/" and "/1818" use an empty UnspecifiedIntervalSection for the open
     # end.  The library resolves this to a computed fuzzy date (~10 years out)
     # instead of infinity.  Detect and override to the correct infinite bound.

--- a/dates_test.py
+++ b/dates_test.py
@@ -497,6 +497,23 @@ class TestEdtfWikiExamples:
         assert edtf_interval("2011-10-04T05:00") is None
 
 
+class TestEdtfSetRepresentation:
+    def test_years(self):
+        lo, hi = safe_edtf_interval("[2018..2019]")
+        assert lo == (2018, 1, 1)
+        assert hi == (2019, 12, 31)
+
+    def test_months(self):
+        lo, hi = safe_edtf_interval("[2018-07..2019-02]")
+        assert lo == (2018, 7, 1)
+        assert hi == (2019, 2, 28)
+
+    def test_days(self):
+        lo, hi = safe_edtf_interval("[1628-06-23..1628-09-03]")
+        assert lo == (1628, 6, 23)
+        assert hi == (1628, 9, 3)
+
+
 class TestIsOneDayOff:
     """_is_one_day_off(plain_lo, plain_hi, lo, hi) — all args are DateTuples."""
 

--- a/dates_test.py
+++ b/dates_test.py
@@ -513,6 +513,11 @@ class TestEdtfSetRepresentation:
         assert lo == (1628, 6, 23)
         assert hi == (1628, 9, 3)
 
+    def test_mix(self):
+        lo, hi = safe_edtf_interval("[2011-09..2012]")
+        assert lo == (2011, 9, 1)
+        assert hi == (2012, 12, 31)
+
 
 class TestIsOneDayOff:
     """_is_one_day_off(plain_lo, plain_hi, lo, hi) — all args are DateTuples."""

--- a/dates_test.py
+++ b/dates_test.py
@@ -519,6 +519,12 @@ class TestEdtfSetRepresentation:
         assert hi == (2012, 12, 31)
 
 
+class TestTimeZone:
+    def test_timezone(self):
+        lo, hi = safe_edtf_interval("2007-11-04T02:00-05:00")
+        lo, hi = safe_edtf_interval("2007-11-04T02:00:00-05:00")
+
+
 class TestIsOneDayOff:
     """_is_one_day_off(plain_lo, plain_hi, lo, hi) — all args are DateTuples."""
 


### PR DESCRIPTION
This special cases a few patterns that pop up in OHM but fail to parse with [python-edtf](https://pypi.org/project/edtf/).

TODO: make a Python EDTF parsing library that can parse everything in the test set for python-edtf, edtf.js and go-edtf.

cc @jeffreyameyer