### PR TITLE
Flag to save more examples

### DIFF
--- a/chrono_stats.py
+++ b/chrono_stats.py
@@ -391,6 +391,12 @@ def main() -> None:
     )
     parser.add_argument("osm_file", help="Path to the .osm.pbf file")
     parser.add_argument("--output_dir", default=".")
+    parser.add_argument(
+        "--max_examples",
+        default=5000,
+        type=int,
+        help="Truncate example files to a random sample after this many.",
+    )
 
     args = parser.parse_args()
     log_start("chronology")
@@ -441,6 +447,7 @@ def main() -> None:
             "date-edtf-invalid-dot-dot": handler.n_dot_dot_edtf,
             "date-edtf-mismatch-off-by-one-day": handler.n_edtf_off_by_one,
         },
+        max_examples=args.max_examples,
     )
 
 

--- a/stats.py
+++ b/stats.py
@@ -32,6 +32,8 @@ def write_stats(
     examples: dict[str, list[tuple[str, int, str]]],
     other_stats: dict[str, int | float],
     preserve_sort_order=False,
+    max_examples=5000,
+    sample_size=1000,
 ):
     out_dir = Path(out_dir)
     with open(out_dir / f"{name}.summary.csv", "w") as f:
@@ -51,13 +53,13 @@ def write_stats(
     for typ, rs in sorted(examples.items()):
         with open(out_dir / f"{typ}.examples.txt", "w") as f:
             if preserve_sort_order:
-                to_out = rs if len(rs) < 5_000 else rs[:2_500]
+                to_out = rs if len(rs) < max_examples else rs[:2_500]
             else:
                 rs_sorted = sorted(rs)
                 to_out = (
                     rs_sorted
-                    if len(rs_sorted) < 5_000
-                    else rng.sample(rs_sorted, 1_000)
+                    if len(rs_sorted) < max_examples
+                    else rng.sample(rs_sorted, sample_size)
                 )
             f.writelines(
                 f"{ftype}/{fid}: {problems}\n" for ftype, fid, problems in to_out


### PR DESCRIPTION
Useful when ohmdash.pages.dev truncates the examples list. Usage:

```
$ uv run chrono_stats.py planet-260511_0301.osm.pbf --output_dir /tmp/chrono-today --max_examples 100000
$ uv run chrono_stats.py planet-260510_0316.osm.pbf --output_dir /tmp/chrono-yesterday --max_examples 100000
$ webdiff /tmp/chrono-yesterday/date-end-no-start.examples.txt /tmp/chrono-today/date-end-no-start.examples.txt
```