### PR TITLE
Fetch latest planet from state.txt instead of guessing by date

### DIFF
--- a/stats-pipeline.sh
+++ b/stats-pipeline.sh
@@ -22,7 +22,8 @@ last_modified=$(curl -fsIL "$planet_url" | grep -i '^last-modified:' | tail -1 |
 date=$(date -u -d "$last_modified" +%Y-%m-%d)
 
 dir=$dashdir/daily/$date
-mkdir -p $dir
+# Create the output dirs up front: on a fresh run none of them exist yet.
+mkdir -p "$dir" "$dashdir/boundary" "$dashdir/dashboard"
 ./extract-stats.sh $planet $dir
 ./update-boundary.sh $planet $dashdir/boundary
 

--- a/stats-pipeline.sh
+++ b/stats-pipeline.sh
@@ -3,23 +3,20 @@ set -o errexit
 set -o pipefail
 set -x
 
-dashdir=$1
+date=$1  # 2026-03-01
+dashdir=$2
 
 # remove any previous download (no error on a fresh run)
 rm -f planet-*.osm.pbf
 
-# Get the latest planet from state.txt instead of guessing by date.
-# state.txt holds the public URL of the latest planet, so download it directly
-# (no S3 credentials needed for the planet bucket).
-state_url=${PLANET_STATE_TXT_URL:-https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/state.txt}
-planet_url=$(curl -fsSL "$state_url")            # http://planet.openhistoricalmap.org.s3.amazonaws.com/planet/planet-260601_0301.osm.pbf
-planet=$(basename "$planet_url")                 # planet-260601_0301.osm.pbf
-curl -fL -o "$planet" "$planet_url"
+yymmdd=${date//-/}
+yymmdd=${yymmdd/#20/}  # 260301
 
-# Derive the date from the planet's Last-Modified header (works for any filename,
-# e.g. a future planet-latest.osm.pbf).
-last_modified=$(curl -fsIL "$planet_url" | grep -i '^last-modified:' | tail -1 | sed 's/^[Ll]ast-[Mm]odified:[ ]*//; s/\r$//')
-date=$(date -u -d "$last_modified" +%Y-%m-%d)
+# Fetch the planet for this specific date. The wildcard resolves the time suffix
+# (planet-260301_0301.osm.pbf). If it isn't there yet, the run fails instead of
+# falling back to an older planet, so we never run twice on the same planet file.
+s3cmd get --force s3://planet.openhistoricalmap.org/planet/planet-${yymmdd}*
+planet=planet-${yymmdd}_*.osm.pbf
 
 dir=$dashdir/daily/$date
 # Create the output dirs up front: on a fresh run none of them exist yet.

--- a/stats-pipeline.sh
+++ b/stats-pipeline.sh
@@ -29,8 +29,8 @@ mkdir -p $dir
 uv run collate_stats.py --start_fresh '' $dashdir/daily/'????-??-??'
 cp $dir/stats.csv $dashdir/dashboard/
 
-# Show the daily diff
-cat $dir/diff.txt
+# Show the daily diff (only exists once there are 2+ days)
+cat "$dir/diff.txt" 2>/dev/null || echo "no diff yet (need 2+ days of stats)"
 
 # leave today's download for followup work
 # rm $planet

--- a/stats-pipeline.sh
+++ b/stats-pipeline.sh
@@ -1,18 +1,25 @@
 #!/usr/bin/env bash
 set -o errexit
+set -o pipefail
 set -x
 
-date=$1  # 2026-03-01
-dashdir=$2
+dashdir=$1
 
-# remove yesterday's download
-rm $(ls planet-*.osm.pbf | tail -1)
+# remove any previous download (no error on a fresh run)
+rm -f planet-*.osm.pbf
 
-yymmdd=${date//-/}
-yymmdd=${yymmdd/#20/}  # 260301
+# Get the latest planet from state.txt instead of guessing by date.
+# state.txt holds the public URL of the latest planet, so download it directly
+# (no S3 credentials needed for the planet bucket).
+state_url=${PLANET_STATE_TXT_URL:-https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/state.txt}
+planet_url=$(curl -fsSL "$state_url")            # http://planet.openhistoricalmap.org.s3.amazonaws.com/planet/planet-260601_0301.osm.pbf
+planet=$(basename "$planet_url")                 # planet-260601_0301.osm.pbf
+curl -fL -o "$planet" "$planet_url"
 
-s3cmd get --force s3://planet.openhistoricalmap.org/planet/planet-${yymmdd}*
-planet=planet-${yymmdd}_*.osm.pbf
+# Derive the date from the planet's Last-Modified header (works for any filename,
+# e.g. a future planet-latest.osm.pbf).
+last_modified=$(curl -fsIL "$planet_url" | grep -i '^last-modified:' | tail -1 | sed 's/^[Ll]ast-[Mm]odified:[ ]*//; s/\r$//')
+date=$(date -u -d "$last_modified" +%Y-%m-%d)
 
 dir=$dashdir/daily/$date
 mkdir -p $dir


### PR DESCRIPTION
I fixed a bit the code to fetch latest planet  data  from https://s3.amazonaws.com/planet.openhistoricalmap.org/planet/state.txt  instead of using the date, which sometime trigger  some errors when the planet file does not exist yet. 